### PR TITLE
Fix #2: Table row detail popup on small screens

### DIFF
--- a/src/Web/Pages/Leagues/ViewLeague.cshtml
+++ b/src/Web/Pages/Leagues/ViewLeague.cshtml
@@ -51,7 +51,19 @@
             {
                 foreach (var standing in Model.LeagueSeason.Standings)
                 {
-                    <tr>
+                    <tr class="js-detail-row"
+                        data-place="@standing.Place"
+                        data-name="@standing.UserFullName"
+                        data-m="@standing.MatchesPlayed"
+                        data-z="@standing.MatchesWon"
+                        data-r="@standing.MatchesTied"
+                        data-p="@standing.MatchesLost"
+                        data-pkt="@standing.BigPoints"
+                        data-pktdk="@standing.BonusPoints"
+                        data-pz="@standing.SmallPointsGained"
+                        data-ps="@standing.SmallPointsLost"
+                        data-rp="@standing.SmallPointsBalance"
+                        data-best="@standing.Best">
                         <td class="text-center">@standing.Place</td>
                         <td>@standing.UserFullName</td>
                         <td class="text-center d-none d-md-table-cell">@standing.MatchesPlayed</td>
@@ -78,12 +90,82 @@
     }
 </div>
 
+<div class="modal fade" id="rowDetailModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Szczegóły zawodnika</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Zamknij"></button>
+            </div>
+            <div class="modal-body" id="rowDetailBody"></div>
+        </div>
+    </div>
+</div>
+
 @section Scripts {
     <script>
         document.addEventListener("DOMContentLoaded", function () {
             const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
             tooltipTriggerList.map(function (tooltipTriggerEl) {
                 return new bootstrap.Tooltip(tooltipTriggerEl);
+            });
+
+            const modal = bootstrap.Modal.getOrCreateInstance(document.getElementById('rowDetailModal'));
+            const modalBody = document.getElementById('rowDetailBody');
+
+            function buildDetailDl(fields) {
+                const fragment = document.createDocumentFragment();
+                let dl = null;
+                fields.forEach(function (field) {
+                    if (field === null) {
+                        const hr = document.createElement('hr');
+                        hr.className = 'my-2';
+                        fragment.appendChild(hr);
+                        dl = null;
+                        return;
+                    }
+                    if (!dl) {
+                        dl = document.createElement('dl');
+                        dl.className = 'row mb-0';
+                        fragment.appendChild(dl);
+                    }
+                    const [label, value] = field;
+                    const dt = document.createElement('dt');
+                    dt.className = 'col-5';
+                    dt.textContent = label;
+                    const dd = document.createElement('dd');
+                    dd.className = 'col-7';
+                    dd.textContent = value;
+                    dl.appendChild(dt);
+                    dl.appendChild(dd);
+                });
+                return fragment;
+            }
+
+            document.querySelectorAll('tr.js-detail-row').forEach(function (row) {
+                row.addEventListener('click', function () {
+                    if (window.innerWidth >= 768) return;
+                    const d = row.dataset;
+                    modalBody.innerHTML = '';
+                    modalBody.appendChild(buildDetailDl([
+                        ['Zawodnik', d.name],
+                        ['Pozycja', d.place],
+                        ['Mecze rozegrane', d.m],
+                        ['Zwycięstwa', d.z],
+                        ['Remisy', d.r],
+                        ['Porażki', d.p],
+                        null,
+                        ['Punkty (1. kryterium)', d.pkt],
+                        ['Punkty (2. kryterium)', d.pktdk],
+                        null,
+                        ['Punkty meczowe zdobyte', d.pz],
+                        ['Punkty meczowe stracone', d.ps],
+                        ['Różnica punktów', d.rp],
+                        null,
+                        ['Najlepszy singiel', d.best]
+                    ]));
+                    modal.show();
+                });
             });
         });
     </script>

--- a/src/Web/Pages/Matches/ViewMatch.cshtml
+++ b/src/Web/Pages/Matches/ViewMatch.cshtml
@@ -39,7 +39,13 @@
                 @for (var i = 0; i < Match.SOLVES_PER_MATCH; i++)
                 {
                     var scramble = Model.MatchDetails.Scrambles[i];
-                    <tr>
+                    <tr class="js-detail-row"
+                        data-solve="@(i + 1)"
+                        data-usera="@Model.MatchDetails.UserAFullName"
+                        data-solve-a="@Model.MatchDetails.SolvesUserA[i]"
+                        data-userb="@(Model.MatchDetails.UserBFullName ?? "")"
+                        data-solve-b="@(string.IsNullOrEmpty(Model.MatchDetails.UserBFullName) ? "" : Model.MatchDetails.SolvesUserB[i])"
+                        data-scramble="@(scramble ?? "")">
                         <td class="text-center">@(i+1).</td>
                         <td class="text-center">@Model.MatchDetails.SolvesUserA[i]</td>
                         @if (!string.IsNullOrEmpty(Model.MatchDetails.UserBFullName))
@@ -93,6 +99,54 @@
             </table>
         </div>
         }
-
-
 </div>
+
+<div class="modal fade" id="rowDetailModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Szczegóły ułożenia</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Zamknij"></button>
+            </div>
+            <div class="modal-body" id="rowDetailBody"></div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script>
+        document.addEventListener("DOMContentLoaded", function () {
+            const modal = bootstrap.Modal.getOrCreateInstance(document.getElementById('rowDetailModal'));
+            const modalBody = document.getElementById('rowDetailBody');
+
+            function addField(dl, label, value, extraClass) {
+                const dt = document.createElement('dt');
+                dt.className = 'col-5';
+                dt.textContent = label;
+                const dd = document.createElement('dd');
+                dd.className = 'col-7' + (extraClass ? ' ' + extraClass : '');
+                dd.textContent = value;
+                dl.appendChild(dt);
+                dl.appendChild(dd);
+            }
+
+            document.querySelectorAll('tr.js-detail-row').forEach(function (row) {
+                row.addEventListener('click', function () {
+                    if (window.innerWidth >= 768) return;
+                    const d = row.dataset;
+                    const dl = document.createElement('dl');
+                    dl.className = 'row mb-0';
+                    addField(dl, 'Ułożenie', d.solve);
+                    addField(dl, d.usera, d.solveA);
+                    if (d.userb) addField(dl, d.userb, d.solveB);
+                    addField(dl, 'Scramble',
+                        d.scramble || 'nie znaleziono scrambla',
+                        'font-monospace' + (d.scramble ? '' : ' fst-italic text-muted'));
+                    modalBody.innerHTML = '';
+                    modalBody.appendChild(dl);
+                    modal.show();
+                });
+            });
+        });
+    </script>
+}

--- a/src/Web/Pages/Rounds/ViewRound.cshtml
+++ b/src/Web/Pages/Rounds/ViewRound.cshtml
@@ -78,7 +78,18 @@
             {
                 foreach (var standing in Model.RoundDetail.Standings)
                 {
-                    <tr>
+                    <tr class="js-detail-row"
+                        data-place="@standing.Place"
+                        data-name="@standing.UserFullName"
+                        data-league="@standing.LeagueIdentifier"
+                        data-best="@standing.Best"
+                        data-avg="@standing.Average"
+                        data-s1="@standing.Solve1"
+                        data-s2="@standing.Solve2"
+                        data-s3="@standing.Solve3"
+                        data-s4="@standing.Solve4"
+                        data-s5="@standing.Solve5"
+                        data-pts="@standing.Points">
                         <td class="text-center">@standing.Place</td>
                         <td>@standing.UserFullName</td>
                         <td class="d-none d-md-table-cell">@standing.LeagueIdentifier</td>
@@ -103,3 +114,62 @@
         </table>
     }
 </div>
+
+<div class="modal fade" id="rowDetailModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Szczegóły zawodnika</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Zamknij"></button>
+            </div>
+            <div class="modal-body" id="rowDetailBody"></div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script>
+        document.addEventListener("DOMContentLoaded", function () {
+            const modal = bootstrap.Modal.getOrCreateInstance(document.getElementById('rowDetailModal'));
+            const modalBody = document.getElementById('rowDetailBody');
+
+            function buildDetailDl(fields) {
+                const dl = document.createElement('dl');
+                dl.className = 'row mb-0';
+                fields.forEach(function ([label, value]) {
+                    const dt = document.createElement('dt');
+                    dt.className = 'col-5';
+                    dt.textContent = label;
+                    const dd = document.createElement('dd');
+                    dd.className = 'col-7';
+                    dd.textContent = value;
+                    dl.appendChild(dt);
+                    dl.appendChild(dd);
+                });
+                return dl;
+            }
+
+            document.querySelectorAll('tr.js-detail-row').forEach(function (row) {
+                row.addEventListener('click', function () {
+                    if (window.innerWidth >= 768) return;
+                    const d = row.dataset;
+                    modalBody.innerHTML = '';
+                    modalBody.appendChild(buildDetailDl([
+                        ['Zawodnik', d.name],
+                        ['Pozycja', d.place],
+                        ['Liga', d.league],
+                        ['Best', d.best],
+                        ['Ao5', d.avg],
+                        ['Ułożenie 1', d.s1],
+                        ['Ułożenie 2', d.s2],
+                        ['Ułożenie 3', d.s3],
+                        ['Ułożenie 4', d.s4],
+                        ['Ułożenie 5', d.s5],
+                        ['Punkty', d.pts]
+                    ]));
+                    modal.show();
+                });
+            });
+        });
+    </script>
+}

--- a/src/Web/wwwroot/css/site.css
+++ b/src/Web/wwwroot/css/site.css
@@ -87,6 +87,10 @@ body {
     }
 }
 
+@media (max-width: 767.98px) {
+    tr.js-detail-row { cursor: pointer; }
+}
+
 /* Hide Bootstrap's default caret, use our own chevron icon */
 .navbar .dropdown-toggle::after {
     display: none;


### PR DESCRIPTION
## Summary

Closes #2

- Clicking any row on `/Leagues` or `/Rounds` standings tables, or a solve row on `/Matches/{id}`, opens a Bootstrap modal with the full record data on viewports narrower than 768 px
- On desktop (≥ 768 px) the click does nothing — behaviour is unchanged
- Hidden columns exposed per page:
  - **Leagues** — match record (M/Z/R/P), small points (PZ/PS), difference (RP), best single — grouped with `<hr>` separators
  - **Rounds** — league identifier, individual solves (Ułożenie 1–5)
  - **Matches** — scramble notation per solve (only solve rows; summary rows are not clickable)
- `cursor: pointer` added via CSS media query for mobile rows only

## Test plan

- [x] Open `/Leagues` on a mobile viewport — click a row, verify modal shows full player data with section separators
- [x] Open `/Rounds` on a mobile viewport — click a row, verify modal shows league + all 5 solve times
- [x] Open `/Matches/{id}` on a mobile viewport — click a solve row, verify modal shows player times and scramble; click Best/Ao5/Wynik rows and confirm no modal opens
- [x] Verify no modal opens on any page at desktop width (≥ 768 px)
- [x] Verify modal closes via the × button and backdrop click

🤖 Generated with [Claude Code](https://claude.com/claude-code)