### PR TITLE
Add CI/CD workflows and document development workflow

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,0 +1,104 @@
+name: Project Automation
+
+on:
+  create:
+  pull_request:
+    types: [opened, closed]
+    branches: [staging]
+
+env:
+  PROJECT_ID: PVT_kwHOBF8AFc4BTr28
+  STATUS_FIELD_ID: PVTSSF_lAHOBF8AFc4BTr28zhA5Keg
+  IN_PROGRESS_OPTION_ID: 47fc9ee4
+  REVIEW_OPTION_ID: 19d1e540
+  TESTING_OPTION_ID: 825d204e
+
+jobs:
+  branch-created:
+    name: Move to In Progress on branch create
+    if: github.actor == 'kamilprzyb2' && github.event_name == 'create' && github.event.ref_type == 'branch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract issue number from branch name
+        id: parse
+        run: |
+          BRANCH="${{ github.event.ref }}"
+          ISSUE=$(echo "$BRANCH" | grep -oP '(?<=/)\d+(?=-)' | head -1)
+          echo "issue=$ISSUE" >> $GITHUB_OUTPUT
+
+      - name: Move issue to In Progress
+        if: steps.parse.outputs.issue != ''
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.parse.outputs.issue }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          ITEM_ID=$(gh api graphql \
+            -f query='query($owner:String!,$repo:String!,$num:Int!){repository(owner:$owner,name:$repo){issue(number:$num){projectItems(first:10){nodes{id project{id}}}}}}' \
+            -f owner="$REPO_OWNER" -f repo="$REPO_NAME" -F num="$ISSUE_NUMBER" \
+            --jq ".data.repository.issue.projectItems.nodes[] | select(.project.id == \"$PROJECT_ID\") | .id")
+
+          gh api graphql \
+            -f query='mutation($proj:ID!,$item:ID!,$field:ID!,$val:String!){updateProjectV2ItemFieldValue(input:{projectId:$proj,itemId:$item,fieldId:$field,value:{singleSelectOptionId:$val}}){projectV2Item{id}}}' \
+            -f proj="$PROJECT_ID" -f item="$ITEM_ID" -f field="$STATUS_FIELD_ID" -f val="$IN_PROGRESS_OPTION_ID"
+
+  pr-opened:
+    name: Move to Review on PR open
+    if: github.actor == 'kamilprzyb2' && github.event.action == 'opened'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract issue number from PR body
+        id: parse
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          ISSUE=$(echo "$PR_BODY" | grep -ioP '(?:closes|fixes|resolves)\s+#\K\d+' | head -1)
+          echo "issue=$ISSUE" >> $GITHUB_OUTPUT
+
+      - name: Move issue to Review
+        if: steps.parse.outputs.issue != ''
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.parse.outputs.issue }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          ITEM_ID=$(gh api graphql \
+            -f query='query($owner:String!,$repo:String!,$num:Int!){repository(owner:$owner,name:$repo){issue(number:$num){projectItems(first:10){nodes{id project{id}}}}}}' \
+            -f owner="$REPO_OWNER" -f repo="$REPO_NAME" -F num="$ISSUE_NUMBER" \
+            --jq ".data.repository.issue.projectItems.nodes[] | select(.project.id == \"$PROJECT_ID\") | .id")
+
+          gh api graphql \
+            -f query='mutation($proj:ID!,$item:ID!,$field:ID!,$val:String!){updateProjectV2ItemFieldValue(input:{projectId:$proj,itemId:$item,fieldId:$field,value:{singleSelectOptionId:$val}}){projectV2Item{id}}}' \
+            -f proj="$PROJECT_ID" -f item="$ITEM_ID" -f field="$STATUS_FIELD_ID" -f val="$REVIEW_OPTION_ID"
+
+  pr-merged:
+    name: Move to Testing on PR merge to staging
+    if: github.actor == 'kamilprzyb2' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract issue number from PR body
+        id: parse
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          ISSUE=$(echo "$PR_BODY" | grep -ioP '(?:closes|fixes|resolves)\s+#\K\d+' | head -1)
+          echo "issue=$ISSUE" >> $GITHUB_OUTPUT
+
+      - name: Move issue to Testing
+        if: steps.parse.outputs.issue != ''
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          ISSUE_NUMBER: ${{ steps.parse.outputs.issue }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          ITEM_ID=$(gh api graphql \
+            -f query='query($owner:String!,$repo:String!,$num:Int!){repository(owner:$owner,name:$repo){issue(number:$num){projectItems(first:10){nodes{id project{id}}}}}}' \
+            -f owner="$REPO_OWNER" -f repo="$REPO_NAME" -F num="$ISSUE_NUMBER" \
+            --jq ".data.repository.issue.projectItems.nodes[] | select(.project.id == \"$PROJECT_ID\") | .id")
+
+          gh api graphql \
+            -f query='mutation($proj:ID!,$item:ID!,$field:ID!,$val:String!){updateProjectV2ItemFieldValue(input:{projectId:$proj,itemId:$item,fieldId:$field,value:{singleSelectOptionId:$val}}){projectV2Item{id}}}' \
+            -f proj="$PROJECT_ID" -f item="$ITEM_ID" -f field="$STATUS_FIELD_ID" -f val="$TESTING_OPTION_ID"

--- a/.github/workflows/staging-docker.yml
+++ b/.github/workflows/staging-docker.yml
@@ -1,0 +1,44 @@
+name: Build and Push Staging Image
+
+on:
+  push:
+    branches: [staging]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/bld-league
+
+jobs:
+  build-and-push:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: src/Web/Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:staging
+
+      - name: Trigger Portainer redeploy
+        env:
+          WEBHOOK_URL: ${{ secrets.PORTAINER_WEBHOOK_URL }}
+        run: |
+          if [ -n "$WEBHOOK_URL" ]; then
+            curl -X POST --fail-with-body "$WEBHOOK_URL"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,30 @@ dotnet ef migrations add MigrationName --project src/Infrastructure --startup-pr
 - WCA OAuth credentials (`ClientId`, `ClientSecret`) go under the `WCA` section — use user secrets in development (`UserSecretsId` is set in `Web.csproj`).
 - Database migrations are applied automatically on startup via `EnsureMigratedHelper`.
 
+## Development Workflow
+
+### Issues
+- Every piece of work starts with a GitHub issue.
+- Use the existing issue templates (feature request, hotfix) where applicable.
+- Every issue must have exactly one **type** label (`type: bug`, `type: chore`, `type: feature`) and one **priority** label (`priority: low`, `priority: medium`, `priority: high`).
+
+### Branch Naming
+Branches that reference an issue must include the issue number and follow this pattern:
+- `feature/15-short-description` — new features (`type: feature`)
+- `fix/12-short-description` — bug fixes (`type: bug`)
+- `chore/7-short-description` — chores (`type: chore`)
+
+Other branch types (`refactor/something`, `project-management/something`, etc.) are also valid but are not tied to any issue and will not trigger project automation workflows.
+
+### Pull Requests & Merge Flow
+- All PRs target `staging` first — never merge a feature/fix branch directly into `main`.
+- PR body must include `Closes #<issue-number>` so the issue is linked and automation triggers correctly.
+- Once staging is verified, `staging` is merged into `main`.
+
+### Agent Git Behaviour
+- Local commits may be created without asking for confirmation.
+- Before pushing to `origin`, always show a summary of what will be pushed and ask for explicit confirmation.
+
 ## Architecture
 
 The solution follows a **Clean Architecture** with four projects:


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for project board automation (branch create → In Progress, PR opened → Review, PR merged to staging → Testing)
- Add GitHub Actions workflow to build and push Docker image to GHCR on merge to staging, with optional Portainer webhook
- Document development workflow in CLAUDE.md (issues, branch naming, PR flow, agent git behaviour)

## Test plan
- [x] Add `PROJECT_TOKEN` secret and verify project automation triggers correctly
- [ ] Add `PORTAINER_WEBHOOK_URL` secret when Portainer is ready
- [x] Verify Docker image is pushed to GHCR on staging merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)