### PR TITLE
Add optional environment badge to navbar

### DIFF
--- a/src/Web/Options/EnvironmentBadgeOptions.cs
+++ b/src/Web/Options/EnvironmentBadgeOptions.cs
@@ -1,0 +1,7 @@
+namespace BldLeague.Web.Options;
+
+public class EnvironmentBadgeOptions
+{
+    public string? Name { get; set; }
+    public string? Color { get; set; }
+}

--- a/src/Web/Pages/Shared/_Layout.cshtml
+++ b/src/Web/Pages/Shared/_Layout.cshtml
@@ -1,4 +1,7 @@
-﻿<!DOCTYPE html>
+﻿@using Microsoft.Extensions.Options
+@using BldLeague.Web.Options
+@inject IOptions<EnvironmentBadgeOptions> EnvironmentBadge
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8"/>
@@ -28,7 +31,13 @@
 <header>
     <nav class="navbar navbar-expand-sm navbar-toggleable-sm border-bottom box-shadow mb-1">
         <div class="container">
-            <a class="navbar-brand" asp-area="" asp-page="/Index">3BLD League</a>
+            <a class="navbar-brand d-flex flex-column align-items-start lh-1" asp-area="" asp-page="/Index">
+                3BLD League
+                @if (!string.IsNullOrEmpty(EnvironmentBadge.Value.Name))
+                {
+                    <span class="badge mt-1" style="background-color: @EnvironmentBadge.Value.Color; font-size: 0.75rem;">@EnvironmentBadge.Value.Name</span>
+                }
+            </a>
 
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse"
                     aria-controls="navbarSupportedContent"

--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -8,6 +8,7 @@ using BldLeague.Infrastructure;
 using BldLeague.Infrastructure.Context;
 using BldLeague.Infrastructure.Helpers;
 using BldLeague.Web.Auth;
+using BldLeague.Web.Options;
 using MediatR;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OAuth;
@@ -24,6 +25,8 @@ builder.Services.AddRazorPages();
 
 builder.Services.AddBldLeagueInfrastructure(builder.Configuration.GetConnectionString("Default") ?? string.Empty);
 builder.Services.AddBldLeagueApplication();
+
+builder.Services.Configure<EnvironmentBadgeOptions>(builder.Configuration.GetSection("EnvironmentBadge"));
 
 builder.Services.AddAuthentication(options =>
     {

--- a/src/Web/appsettings.json
+++ b/src/Web/appsettings.json
@@ -16,5 +16,9 @@
   "WCA": {
     "ClientId": "",
     "ClientSecret": ""
+  },
+  "EnvironmentBadge": {
+    "Name": "",
+    "Color": ""
   }
 }


### PR DESCRIPTION
## Summary
- Adds `EnvironmentBadgeOptions` (`Name` + `Color`) bound to the `EnvironmentBadge` config section
- Registers the options on startup via `Configure<EnvironmentBadgeOptions>`
- Renders a small coloured badge below the "3BLD League" title in the navbar when `Name` is non-empty
- Production default has empty values — no badge shown

## Test plan
- [x] Set `EnvironmentBadge.Name = "staging"` and `Color = "#dc3545"` in appsettings — red badge appears below site title
- [x] Remove / leave `Name` empty — no badge rendered
- [x] Verify layout on mobile (collapsed navbar)

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)