### PR TITLE
Fix dark mode flash on page load

### DIFF
--- a/src/Web/Pages/Shared/_Layout.cshtml
+++ b/src/Web/Pages/Shared/_Layout.cshtml
@@ -19,7 +19,7 @@
 
     <script>
         (function () {
-            const savedTheme = localStorage.getItem("bs-theme") || "light";
+            const savedTheme = localStorage.getItem("bsTheme") || "dark";
             document.documentElement.setAttribute("data-bs-theme", savedTheme);
         })();
     </script>
@@ -157,23 +157,15 @@
 <script src="~/js/site.js" asp-append-version="true"></script>
 
 <script>
-    document.addEventListener('DOMContentLoaded', (event) => {
-        const htmlElement = document.documentElement;
+    document.addEventListener('DOMContentLoaded', function () {
         const switchElement = document.getElementById('darkModeSwitch');
-
-        // Set the default theme to dark if no setting is found in local storage
         const currentTheme = localStorage.getItem('bsTheme') || 'dark';
-        htmlElement.setAttribute('data-bs-theme', currentTheme);
         switchElement.checked = currentTheme === 'dark';
 
         switchElement.addEventListener('change', function () {
-            if (this.checked) {
-                htmlElement.setAttribute('data-bs-theme', 'dark');
-                localStorage.setItem('bsTheme', 'dark');
-            } else {
-                htmlElement.setAttribute('data-bs-theme', 'light');
-                localStorage.setItem('bsTheme', 'light');
-            }
+            const theme = this.checked ? 'dark' : 'light';
+            document.documentElement.setAttribute('data-bs-theme', theme);
+            localStorage.setItem('bsTheme', theme);
         });
     });
 </script>


### PR DESCRIPTION
## Summary
- Fixed mismatched localStorage key in head IIFE (`"bs-theme"` → `"bsTheme"`)
- Fixed default theme in head IIFE (`"light"` → `"dark"`) to match the toggle's default
- Removed redundant `data-bs-theme` assignment from `DOMContentLoaded`, eliminating the flash

## Test plan
- [x] Enable dark mode via navbar toggle, hard-refresh (Ctrl+Shift+R) — no flash of light mode
- [x] Clear localStorage, reload — page renders in dark mode by default
- [x] Toggle between dark/light, reload — preference is preserved

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)