### PR TITLE
Add preload hint for Bootstrap Icons font to reduce FOIT

### DIFF
--- a/src/Web/Pages/Shared/_Layout.cshtml
+++ b/src/Web/Pages/Shared/_Layout.cshtml
@@ -10,6 +10,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="~/favicon-16x16.png"/>
     <link rel="apple-touch-icon" sizes="180x180" href="~/apple-touch-icon.png"/>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css"/>
+    <link rel="preload" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/fonts/bootstrap-icons.woff2" as="font" type="font/woff2" crossorigin>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true"/>
     <link rel="stylesheet" href="~/Web.styles.css" asp-append-version="true"/>


### PR DESCRIPTION
## Summary
- Adds `<link rel="preload">` for the Bootstrap Icons woff2 font file in `_Layout.cshtml`
- Instructs the browser to fetch the font in parallel with CSS parsing, reducing the flash of invisible icons (FOIT) on page load

## Test plan
- [x] Hard refresh (Ctrl+Shift+R) — icons should appear faster / with less flash
- [x] Normal navigation — no visible change expected

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)