### PR TITLE
Fix pixel offset on match table button rows

### DIFF
--- a/src/Web/Pages/Matches/MatchList.cshtml
+++ b/src/Web/Pages/Matches/MatchList.cshtml
@@ -65,7 +65,7 @@
                         <td class="text-center">@matchSummary.UserBScore</td>
                         <td>@matchSummary.UserBFullName</td>
                     }
-                    <td class="d-flex">
+                    <td>
                         <a class="btn btn-sm btn-primary me-2"
                            asp-page="/Matches/ViewMatch"
                            asp-route-id="@matchSummary.MatchId">


### PR DESCRIPTION
Removes `d-flex` from the action `<td>` in the match list table, which was causing a visual row offset.

Closes #12