### PR TITLE
Set up GitHub MCP server and SSH git auth in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,8 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   zsh \
   man-db \
   unzip \
-  gnupg2 \
-  gh \
+  openssh-client \
   iptables \
   ipset \
   iproute2 \
@@ -52,8 +51,9 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhisto
 ENV DEVCONTAINER=true
 
 # Create workspace and config directories and set permissions
-RUN mkdir -p /workspace /home/node/.claude && \
-  chown -R node:node /workspace /home/node/.claude
+RUN mkdir -p /workspace /home/node/.claude /home/node/.ssh && \
+  chmod 700 /home/node/.ssh && \
+  chown -R node:node /workspace /home/node/.claude /home/node/.ssh
 
 WORKDIR /workspace
 
@@ -94,10 +94,10 @@ RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
 RUN /usr/local/dotnet/dotnet tool install --global dotnet-ef
 ENV PATH=$PATH:/home/node/.dotnet/tools
 
-# Copy and set up firewall script
-COPY init-firewall.sh /usr/local/bin/
+# Copy and set up firewall and GitHub init scripts
+COPY init-firewall.sh init-github.sh /usr/local/bin/
 USER root
-RUN chmod +x /usr/local/bin/init-firewall.sh && \
+RUN chmod +x /usr/local/bin/init-firewall.sh /usr/local/bin/init-github.sh && \
   echo "node ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh" > /etc/sudoers.d/node-firewall && \
   chmod 0440 /etc/sudoers.d/node-firewall
 USER node

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -44,15 +44,17 @@
   "remoteUser": "node",
   "mounts": [
     "source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
-    "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume"
+    "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume",
+    "source=claude-code-ssh-${devcontainerId},target=/home/node/.ssh,type=volume"
   ],
   "containerEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096",
     "CLAUDE_CONFIG_DIR": "/home/node/.claude",
-    "POWERLEVEL9K_DISABLE_GITSTATUS": "true"
+    "POWERLEVEL9K_DISABLE_GITSTATUS": "true",
+    "GITHUB_PERSONAL_ACCESS_TOKEN": "${localEnv:GITHUB_PERSONAL_ACCESS_TOKEN}"
   },
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",
-  "postStartCommand": "sudo /usr/local/bin/init-firewall.sh",
+  "postStartCommand": "sudo /usr/local/bin/init-firewall.sh && /usr/local/bin/init-github.sh",
   "waitFor": "postStartCommand"
 }

--- a/.devcontainer/init-github.sh
+++ b/.devcontainer/init-github.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Generate SSH key for git operations if not present
+SSH_KEY="$HOME/.ssh/id_ed25519"
+if [ ! -f "$SSH_KEY" ]; then
+  mkdir -p "$HOME/.ssh"
+  chmod 700 "$HOME/.ssh"
+  ssh-keygen -t ed25519 -C "bld-league-devcontainer" -f "$SSH_KEY" -N ""
+  echo ""
+  echo "=========================================="
+  echo "New SSH key generated."
+  echo "Add the public key below to GitHub:"
+  echo "https://github.com/settings/ssh/new"
+  echo "=========================================="
+  cat "${SSH_KEY}.pub"
+  echo "=========================================="
+fi
+
+# Trust GitHub's host key
+ssh-keyscan -H github.com >> "$HOME/.ssh/known_hosts" 2>/dev/null
+
+# Use SSH for all GitHub git operations
+git config --global url."git@github.com:".insteadOf "https://github.com/"
+
+# Register GitHub MCP server
+if [ -n "$GITHUB_PERSONAL_ACCESS_TOKEN" ]; then
+  claude mcp add-json github \
+    "{\"type\":\"http\",\"url\":\"https://api.githubcopilot.com/mcp\",\"headers\":{\"Authorization\":\"Bearer $GITHUB_PERSONAL_ACCESS_TOKEN\"}}" \
+    --scope user 2>/dev/null || true
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,10 @@ dotnet ef migrations add MigrationName --project src/Infrastructure --startup-pr
 - WCA OAuth credentials (`ClientId`, `ClientSecret`) go under the `WCA` section — use user secrets in development (`UserSecretsId` is set in `Web.csproj`).
 - Database migrations are applied automatically on startup via `EnsureMigratedHelper`.
 
+## GitHub
+
+Repository: `kamilprzyb2/bld-league`. Use the GitHub MCP server for all GitHub operations (issues, PRs, branches) — do not use the `gh` CLI.
+
 ## Development Workflow
 
 ### Issues


### PR DESCRIPTION
## Summary

- Remove `gh` CLI — GitHub MCP server handles all GitHub API operations (issues, PRs, branches, etc.)
- Add `GITHUB_PERSONAL_ACCESS_TOKEN` via `devcontainer.json` `containerEnv` (reads from Windows host environment)
- Add `init-github.sh`: generates SSH key on first start, adds GitHub to `known_hosts`, rewrites git HTTPS URLs to SSH, registers MCP server — all on `postStartCommand`
- Add dedicated SSH volume to persist key across container rebuilds
- Update `CLAUDE.md` with repo identity and MCP usage guidance for agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)