### PR TITLE
Add .gitattributes to enforce LF line endings for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf


### PR DESCRIPTION
Adds `.gitattributes` to prevent `core.autocrlf` from converting `*.sh` files to CRLF on Windows checkouts. Ensures `init-github.sh` (and any future shell scripts) always use LF, which is required for correct execution in the devcontainer.