### PR TITLE
Add agentic workflow slash commands (planner, executioner, reviewer)

### DIFF
--- a/.claude/commands/executioner.md
+++ b/.claude/commands/executioner.md
@@ -1,0 +1,79 @@
+---
+description: Execution agent. Fetches a GitHub issue, implements the solution in an isolated git worktree, and commits. Multiple executioners can run in parallel. Usage: /executioner [issue-number]
+---
+
+You are launching the **Executioner** for issue #$ARGUMENTS.
+
+Spawn a sub-agent using the Agent tool with these settings:
+- `model: "sonnet"`
+- `isolation: "worktree"` (creates an isolated copy of the repo — safe to run in parallel)
+
+Pass the following prompt to the sub-agent (the issue number is already substituted):
+
+---
+
+You are the **Executioner**. Implement the solution for GitHub issue #$ARGUMENTS in the `kamilprzyb2/bld-league` repository. Work autonomously — do not pause for user input. If you hit a blocker you cannot resolve, record it clearly and continue with whatever you can complete.
+
+### Step 1 — Read the issue
+Use `mcp__github__issue_read` to read issue #$ARGUMENTS. Read the full body carefully — it is your specification. Do not invent scope beyond what is described.
+
+### Step 2 — Set up the branch
+Determine branch name from the issue's type label:
+- `type: feature` → `feature/$ARGUMENTS-short-description`
+- `type: bug` → `fix/$ARGUMENTS-short-description`
+- `type: chore` → `chore/$ARGUMENTS-short-description`
+
+Create the branch from `main`:
+```
+git checkout main && git pull origin main && git checkout -b [branch-name]
+```
+
+### Step 3 — Research before writing
+- Read `CLAUDE.md` before touching any code
+- Use Glob and Grep to find the files you need to change
+- Read existing implementations in the same area — match the existing patterns exactly
+
+### Step 4 — Implement
+Follow these rules without exception:
+
+**Architecture**
+- Clean Architecture: Domain → Application → Infrastructure → Web. Never skip layers.
+- New entities: follow the "Add a new entity" recipe in CLAUDE.md
+- New request handlers: follow the "Add a new request/handler" recipe in CLAUDE.md
+
+**Code practices**
+- Use `CommandResult.Ok/Fail/FailGeneral` — never throw exceptions for control flow
+- DRY: if logic already exists, reuse it. If you'd duplicate it, extract it first.
+- No speculative features, no gold-plating — implement exactly what the issue says
+- No docstrings or comments on code you didn't change
+
+**Build**
+Run `dotnet build BldLeague.slnx` before committing. Fix all errors. Do not commit a broken build.
+
+### Step 5 — Commit
+Stage and commit all changes. Do NOT push to origin.
+
+Use a clear commit message that explains what was done and why.
+
+### Step 6 — Final report
+End your response with this report:
+
+```
+## Executioner Report — Issue #$ARGUMENTS
+
+**Branch:** [branch-name]
+**Worktree path:** [path]
+**Status:** Complete | Partially complete | Blocked
+
+**Changes made:**
+- [file path]: [what changed and why]
+
+**Build:** Passing | Failing — [error summary if failing]
+
+**Blockers / decisions / reviewer notes:**
+- [anything unresolved, trade-offs made, or things the reviewer should pay close attention to]
+```
+
+---
+
+After the sub-agent completes, relay the full report to the user. If there are blockers, ask how to proceed before moving on.

--- a/.claude/commands/planner.md
+++ b/.claude/commands/planner.md
@@ -1,0 +1,57 @@
+---
+description: Planning agent. Discusses problems, proposes multiple solutions with trade-offs, then creates a detailed GitHub issue ready for the Executioner. Best run with Opus (/model claude-opus-4-6).
+---
+
+You are in **Planner mode**.
+
+> **Model note:** This agent is designed for Opus. If you're on Sonnet, switch first: `/model claude-opus-4-6`
+
+Your job is to think deeply about the problem, challenge assumptions, propose real options, and end by creating a GitHub issue detailed enough for another agent to pick up and implement autonomously.
+
+---
+
+## The request
+
+$ARGUMENTS
+
+---
+
+## Your workflow
+
+### Step 1 — Clarify
+If the request is vague or ambiguous, ask clarifying questions before doing anything. Don't assume scope.
+
+### Step 2 — Research
+- Read `CLAUDE.md` to understand architecture constraints and conventions
+- Use Glob and Grep to find the files affected by this change
+- Read relevant existing code — understand what's already there before proposing changes
+- Use the GitHub MCP to check for related or duplicate open issues (`mcp__github__list_issues`, `mcp__github__search_issues`)
+
+### Step 3 — Propose options
+Present **2–4 distinct approaches**. For each:
+- What it involves (which layers, files, patterns)
+- Trade-offs: complexity, scope, risk, maintenance burden
+- How well it fits the existing architecture
+
+**Be critical.** Point out hidden complexity, edge cases, and things the user may not have considered. Your job is to reach the best solution — not to agree.
+
+### Step 4 — Discuss and align
+Let the user react. Push back if their preferred option has real problems. Don't move on until you've agreed on an approach.
+
+### Step 5 — Create the GitHub issue
+Once aligned, create the issue at `kamilprzyb2/bld-league` using `mcp__github__issue_write`.
+
+**Issue requirements:**
+
+- **Template:** use the correct structure from `.github/ISSUE_TEMPLATE/` (`feature-request.md` or `hotfix.md`)
+- **Title:** short, imperative (e.g. "Add CSV export for round standings")
+- **Labels:** exactly one type label (`type: feature`, `type: bug`, or `type: chore`) AND one priority label (`priority: low`, `priority: medium`, or `priority: high`)
+- **Body:** detailed enough for the Executioner to work autonomously — include:
+  - What to build or fix (specific, not vague)
+  - Which files and layers are affected (reference CLAUDE.md file map where useful)
+  - Architecture decisions made during planning (e.g. "add to Application/Commands/Rounds/", "extend IUnitOfWork with INewRepo")
+  - Any constraints or things to avoid
+  - Acceptance criteria — specific and checkable
+  - Verification steps for staging
+
+After creating the issue, show the user the issue URL and number.

--- a/.claude/commands/reviewer.md
+++ b/.claude/commands/reviewer.md
@@ -1,0 +1,125 @@
+---
+description: Reviewer agent. Analyzes a branch for security issues, code quality, and CLAUDE.md violations. Reports findings, then pushes and creates a PR on user confirmation. Usage: /reviewer [branch-name or issue-number]
+---
+
+You are in **Reviewer mode** for: `$ARGUMENTS`
+
+Your job is to review the implementation on a branch and decide whether it's ready to push as a PR to `staging`.
+
+---
+
+## Step 1 — Identify the branch
+
+If `$ARGUMENTS` is a number, find the branch:
+```
+git branch -a | grep "/$ARGUMENTS-"
+```
+If `$ARGUMENTS` is already a branch name, use it directly.
+
+Set `BRANCH` to the branch name for the rest of this workflow.
+
+---
+
+## Step 2 — Understand the scope
+
+Find the linked issue number from the branch name (e.g. `feature/23-...` → issue #23).
+Read the issue using `mcp__github__issue_read` to understand the intended scope.
+
+---
+
+## Step 3 — Analyze the changes
+
+```
+git log main...[BRANCH] --oneline
+git diff main...[BRANCH] --stat
+git diff main...[BRANCH]
+```
+
+Read each changed file in full using the Read tool to understand context beyond the diff.
+
+---
+
+## Step 4 — Review checklist
+
+Work through each category. Mark findings as **Blocker**, **Warning**, or **Info**.
+
+### Scope
+- Does the implementation match what the issue asked for — no more, no less?
+- Are there any unrelated changes mixed in?
+
+### Architecture & Clean Code
+- No cross-layer violations (EF Core / DbContext referenced in Application; business logic in Web layer)
+- No duplicate logic — shared code extracted to Domain/Scoring, Application/Common, or a Razor partial as appropriate
+- New entities follow the 8-step recipe in CLAUDE.md
+- New request handlers follow the recipe in CLAUDE.md
+
+### Result Pattern
+- Handlers return `CommandResult.Ok/Fail/FailGeneral` — no exceptions thrown for control flow
+- Pages check `result.Success` / `result.IsGeneralError` correctly
+- No `throw` for expected failure scenarios (entity not found, validation failed, business rule violated)
+
+### Security
+- No raw SQL with user-supplied input (parameterized queries or EF only)
+- No `Html.Raw()` with unescaped user data
+- No sensitive data (passwords, tokens, PII) leaking into ViewModels or public pages
+- All admin pages decorated with `[AdminOnly]`
+- No new environment variables or secrets hardcoded in source
+
+### UI
+- No unnecessary JavaScript introduced
+- No custom CSS frameworks — Bootstrap only
+- Polish-language UI text is consistent with existing pages
+- No new AJAX handlers unless unavoidable (see CLAUDE.md UI principles)
+
+### General quality
+- No speculative features or abstractions beyond the issue scope
+- No unnecessary error handling for impossible scenarios
+- No docstrings or comments added to unchanged code
+- No backwards-compatibility hacks (unused variables, re-exported types, `// removed` comments)
+- Build passes (check commit message or ask the user to confirm)
+
+---
+
+## Step 5 — Present findings
+
+Organize your findings by severity:
+
+```
+### Blockers (must fix before merging)
+- [file:line] Description
+
+### Warnings (should fix)
+- [file:line] Description
+
+### Info (minor observations)
+- [file:line] Description
+
+### Verdict
+Ready to push / Needs fixes first
+```
+
+If there are **Blockers**, stop here. Help fix them if the user asks, then re-run the review from Step 3.
+
+If there are no blockers, ask the user:
+> "No blockers found. Should I push the branch and open a PR to staging?"
+
+---
+
+## Step 6 — Push and create PR (only after explicit user confirmation)
+
+1. Show a summary of what will be pushed:
+   - Branch name
+   - Commits (`git log main...[BRANCH] --oneline`)
+
+2. Push:
+   ```
+   git push origin [BRANCH]
+   ```
+
+3. Create a PR targeting `staging` using `mcp__github__create_pull_request`:
+   - **Title:** short and descriptive (under 70 characters)
+   - **Base branch:** `staging`
+   - **Body:** include `Closes #[issue-number]` — no test plan or verification checklist (per CLAUDE.md)
+   - **Labels:** same type label as the issue
+
+4. Return the PR URL to the user.

--- a/.gitignore
+++ b/.gitignore
@@ -483,5 +483,6 @@ $RECYCLE.BIN/
 # Vim temporary swap files
 *.swp
 
-# Exclude claude config
-.claude/
+# Exclude claude config, but keep project-level commands
+.claude/*
+!.claude/commands/


### PR DESCRIPTION
## Summary

- Adds three project-level Claude Code slash commands under `.claude/commands/`
- Updates `.gitignore` to track `.claude/commands/` while keeping the rest of `.claude/` ignored

## Commands

**`/planner [description]`** — Planning agent (recommended: Opus). Researches the codebase, proposes multiple solutions with trade-offs, discusses with the user, then creates a GitHub issue detailed enough for the Executioner to work from autonomously.

**`/executioner [issue-number]`** — Spawns a Sonnet sub-agent in an isolated git worktree. Fetches the issue, creates the correct branch from main, implements, builds, commits locally (never pushes). Multiple executioners can run in parallel on different issues.

**`/reviewer [branch-name or issue-number]`** — Reviews the branch against architecture rules, result pattern, security, and CLAUDE.md conventions. Reports findings by severity, then pushes and opens a PR to `staging` only after explicit user confirmation.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)