### PR TITLE
Add player rankings page (single and average)

### DIFF
--- a/.claude/commands/executioner.md
+++ b/.claude/commands/executioner.md
@@ -1,0 +1,79 @@
+---
+description: Execution agent. Fetches a GitHub issue, implements the solution in an isolated git worktree, and commits. Multiple executioners can run in parallel. Usage: /executioner [issue-number]
+---
+
+You are launching the **Executioner** for issue #$ARGUMENTS.
+
+Spawn a sub-agent using the Agent tool with these settings:
+- `model: "sonnet"`
+- `isolation: "worktree"` (creates an isolated copy of the repo — safe to run in parallel)
+
+Pass the following prompt to the sub-agent (the issue number is already substituted):
+
+---
+
+You are the **Executioner**. Implement the solution for GitHub issue #$ARGUMENTS in the `kamilprzyb2/bld-league` repository. Work autonomously — do not pause for user input. If you hit a blocker you cannot resolve, record it clearly and continue with whatever you can complete.
+
+### Step 1 — Read the issue
+Use `mcp__github__issue_read` to read issue #$ARGUMENTS. Read the full body carefully — it is your specification. Do not invent scope beyond what is described.
+
+### Step 2 — Set up the branch
+Determine branch name from the issue's type label:
+- `type: feature` → `feature/$ARGUMENTS-short-description`
+- `type: bug` → `fix/$ARGUMENTS-short-description`
+- `type: chore` → `chore/$ARGUMENTS-short-description`
+
+Create the branch from `main`:
+```
+git checkout main && git pull origin main && git checkout -b [branch-name]
+```
+
+### Step 3 — Research before writing
+- Read `CLAUDE.md` before touching any code
+- Use Glob and Grep to find the files you need to change
+- Read existing implementations in the same area — match the existing patterns exactly
+
+### Step 4 — Implement
+Follow these rules without exception:
+
+**Architecture**
+- Clean Architecture: Domain → Application → Infrastructure → Web. Never skip layers.
+- New entities: follow the "Add a new entity" recipe in CLAUDE.md
+- New request handlers: follow the "Add a new request/handler" recipe in CLAUDE.md
+
+**Code practices**
+- Use `CommandResult.Ok/Fail/FailGeneral` — never throw exceptions for control flow
+- DRY: if logic already exists, reuse it. If you'd duplicate it, extract it first.
+- No speculative features, no gold-plating — implement exactly what the issue says
+- No docstrings or comments on code you didn't change
+
+**Build**
+Run `dotnet build BldLeague.slnx` before committing. Fix all errors. Do not commit a broken build.
+
+### Step 5 — Commit
+Stage and commit all changes. Do NOT push to origin.
+
+Use a clear commit message that explains what was done and why.
+
+### Step 6 — Final report
+End your response with this report:
+
+```
+## Executioner Report — Issue #$ARGUMENTS
+
+**Branch:** [branch-name]
+**Worktree path:** [path]
+**Status:** Complete | Partially complete | Blocked
+
+**Changes made:**
+- [file path]: [what changed and why]
+
+**Build:** Passing | Failing — [error summary if failing]
+
+**Blockers / decisions / reviewer notes:**
+- [anything unresolved, trade-offs made, or things the reviewer should pay close attention to]
+```
+
+---
+
+After the sub-agent completes, relay the full report to the user. If there are blockers, ask how to proceed before moving on.

--- a/.claude/commands/planner.md
+++ b/.claude/commands/planner.md
@@ -1,0 +1,57 @@
+---
+description: Planning agent. Discusses problems, proposes multiple solutions with trade-offs, then creates a detailed GitHub issue ready for the Executioner. Best run with Opus (/model claude-opus-4-6).
+---
+
+You are in **Planner mode**.
+
+> **Model note:** This agent is designed for Opus. If you're on Sonnet, switch first: `/model claude-opus-4-6`
+
+Your job is to think deeply about the problem, challenge assumptions, propose real options, and end by creating a GitHub issue detailed enough for another agent to pick up and implement autonomously.
+
+---
+
+## The request
+
+$ARGUMENTS
+
+---
+
+## Your workflow
+
+### Step 1 — Clarify
+If the request is vague or ambiguous, ask clarifying questions before doing anything. Don't assume scope.
+
+### Step 2 — Research
+- Read `CLAUDE.md` to understand architecture constraints and conventions
+- Use Glob and Grep to find the files affected by this change
+- Read relevant existing code — understand what's already there before proposing changes
+- Use the GitHub MCP to check for related or duplicate open issues (`mcp__github__list_issues`, `mcp__github__search_issues`)
+
+### Step 3 — Propose options
+Present **2–4 distinct approaches**. For each:
+- What it involves (which layers, files, patterns)
+- Trade-offs: complexity, scope, risk, maintenance burden
+- How well it fits the existing architecture
+
+**Be critical.** Point out hidden complexity, edge cases, and things the user may not have considered. Your job is to reach the best solution — not to agree.
+
+### Step 4 — Discuss and align
+Let the user react. Push back if their preferred option has real problems. Don't move on until you've agreed on an approach.
+
+### Step 5 — Create the GitHub issue
+Once aligned, create the issue at `kamilprzyb2/bld-league` using `mcp__github__issue_write`.
+
+**Issue requirements:**
+
+- **Template:** use the correct structure from `.github/ISSUE_TEMPLATE/` (`feature-request.md` or `hotfix.md`)
+- **Title:** short, imperative (e.g. "Add CSV export for round standings")
+- **Labels:** exactly one type label (`type: feature`, `type: bug`, or `type: chore`) AND one priority label (`priority: low`, `priority: medium`, or `priority: high`)
+- **Body:** detailed enough for the Executioner to work autonomously — include:
+  - What to build or fix (specific, not vague)
+  - Which files and layers are affected (reference CLAUDE.md file map where useful)
+  - Architecture decisions made during planning (e.g. "add to Application/Commands/Rounds/", "extend IUnitOfWork with INewRepo")
+  - Any constraints or things to avoid
+  - Acceptance criteria — specific and checkable
+  - Verification steps for staging
+
+After creating the issue, show the user the issue URL and number.

--- a/.claude/commands/reviewer.md
+++ b/.claude/commands/reviewer.md
@@ -1,0 +1,125 @@
+---
+description: Reviewer agent. Analyzes a branch for security issues, code quality, and CLAUDE.md violations. Reports findings, then pushes and creates a PR on user confirmation. Usage: /reviewer [branch-name or issue-number]
+---
+
+You are in **Reviewer mode** for: `$ARGUMENTS`
+
+Your job is to review the implementation on a branch and decide whether it's ready to push as a PR to `staging`.
+
+---
+
+## Step 1 — Identify the branch
+
+If `$ARGUMENTS` is a number, find the branch:
+```
+git branch -a | grep "/$ARGUMENTS-"
+```
+If `$ARGUMENTS` is already a branch name, use it directly.
+
+Set `BRANCH` to the branch name for the rest of this workflow.
+
+---
+
+## Step 2 — Understand the scope
+
+Find the linked issue number from the branch name (e.g. `feature/23-...` → issue #23).
+Read the issue using `mcp__github__issue_read` to understand the intended scope.
+
+---
+
+## Step 3 — Analyze the changes
+
+```
+git log main...[BRANCH] --oneline
+git diff main...[BRANCH] --stat
+git diff main...[BRANCH]
+```
+
+Read each changed file in full using the Read tool to understand context beyond the diff.
+
+---
+
+## Step 4 — Review checklist
+
+Work through each category. Mark findings as **Blocker**, **Warning**, or **Info**.
+
+### Scope
+- Does the implementation match what the issue asked for — no more, no less?
+- Are there any unrelated changes mixed in?
+
+### Architecture & Clean Code
+- No cross-layer violations (EF Core / DbContext referenced in Application; business logic in Web layer)
+- No duplicate logic — shared code extracted to Domain/Scoring, Application/Common, or a Razor partial as appropriate
+- New entities follow the 8-step recipe in CLAUDE.md
+- New request handlers follow the recipe in CLAUDE.md
+
+### Result Pattern
+- Handlers return `CommandResult.Ok/Fail/FailGeneral` — no exceptions thrown for control flow
+- Pages check `result.Success` / `result.IsGeneralError` correctly
+- No `throw` for expected failure scenarios (entity not found, validation failed, business rule violated)
+
+### Security
+- No raw SQL with user-supplied input (parameterized queries or EF only)
+- No `Html.Raw()` with unescaped user data
+- No sensitive data (passwords, tokens, PII) leaking into ViewModels or public pages
+- All admin pages decorated with `[AdminOnly]`
+- No new environment variables or secrets hardcoded in source
+
+### UI
+- No unnecessary JavaScript introduced
+- No custom CSS frameworks — Bootstrap only
+- Polish-language UI text is consistent with existing pages
+- No new AJAX handlers unless unavoidable (see CLAUDE.md UI principles)
+
+### General quality
+- No speculative features or abstractions beyond the issue scope
+- No unnecessary error handling for impossible scenarios
+- No docstrings or comments added to unchanged code
+- No backwards-compatibility hacks (unused variables, re-exported types, `// removed` comments)
+- Build passes (check commit message or ask the user to confirm)
+
+---
+
+## Step 5 — Present findings
+
+Organize your findings by severity:
+
+```
+### Blockers (must fix before merging)
+- [file:line] Description
+
+### Warnings (should fix)
+- [file:line] Description
+
+### Info (minor observations)
+- [file:line] Description
+
+### Verdict
+Ready to push / Needs fixes first
+```
+
+If there are **Blockers**, stop here. Help fix them if the user asks, then re-run the review from Step 3.
+
+If there are no blockers, ask the user:
+> "No blockers found. Should I push the branch and open a PR to staging?"
+
+---
+
+## Step 6 — Push and create PR (only after explicit user confirmation)
+
+1. Show a summary of what will be pushed:
+   - Branch name
+   - Commits (`git log main...[BRANCH] --oneline`)
+
+2. Push:
+   ```
+   git push origin [BRANCH]
+   ```
+
+3. Create a PR targeting `staging` using `mcp__github__create_pull_request`:
+   - **Title:** short and descriptive (under 70 characters)
+   - **Base branch:** `staging`
+   - **Body:** include `Closes #[issue-number]` — no test plan or verification checklist (per CLAUDE.md)
+   - **Labels:** same type label as the issue
+
+4. Return the PR URL to the user.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,8 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   zsh \
   man-db \
   unzip \
-  gnupg2 \
-  gh \
+  openssh-client \
   iptables \
   ipset \
   iproute2 \
@@ -52,8 +51,9 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhisto
 ENV DEVCONTAINER=true
 
 # Create workspace and config directories and set permissions
-RUN mkdir -p /workspace /home/node/.claude && \
-  chown -R node:node /workspace /home/node/.claude
+RUN mkdir -p /workspace /home/node/.claude /home/node/.ssh && \
+  chmod 700 /home/node/.ssh && \
+  chown -R node:node /workspace /home/node/.claude /home/node/.ssh
 
 WORKDIR /workspace
 
@@ -94,10 +94,10 @@ RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
 RUN /usr/local/dotnet/dotnet tool install --global dotnet-ef
 ENV PATH=$PATH:/home/node/.dotnet/tools
 
-# Copy and set up firewall script
-COPY init-firewall.sh /usr/local/bin/
+# Copy and set up firewall and GitHub init scripts
+COPY init-firewall.sh init-github.sh /usr/local/bin/
 USER root
-RUN chmod +x /usr/local/bin/init-firewall.sh && \
+RUN chmod +x /usr/local/bin/init-firewall.sh /usr/local/bin/init-github.sh && \
   echo "node ALL=(root) NOPASSWD: /usr/local/bin/init-firewall.sh" > /etc/sudoers.d/node-firewall && \
   chmod 0440 /etc/sudoers.d/node-firewall
 USER node

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -44,15 +44,17 @@
   "remoteUser": "node",
   "mounts": [
     "source=claude-code-bashhistory-${devcontainerId},target=/commandhistory,type=volume",
-    "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume"
+    "source=claude-code-config-${devcontainerId},target=/home/node/.claude,type=volume",
+    "source=claude-code-ssh-${devcontainerId},target=/home/node/.ssh,type=volume"
   ],
   "containerEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096",
     "CLAUDE_CONFIG_DIR": "/home/node/.claude",
-    "POWERLEVEL9K_DISABLE_GITSTATUS": "true"
+    "POWERLEVEL9K_DISABLE_GITSTATUS": "true",
+    "GITHUB_PERSONAL_ACCESS_TOKEN": "${localEnv:GITHUB_PERSONAL_ACCESS_TOKEN}"
   },
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",
-  "postStartCommand": "sudo /usr/local/bin/init-firewall.sh",
+  "postStartCommand": "sudo /usr/local/bin/init-firewall.sh && /usr/local/bin/init-github.sh",
   "waitFor": "postStartCommand"
 }

--- a/.devcontainer/init-github.sh
+++ b/.devcontainer/init-github.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Generate SSH key for git operations if not present
+SSH_KEY="$HOME/.ssh/id_ed25519"
+if [ ! -f "$SSH_KEY" ]; then
+  mkdir -p "$HOME/.ssh"
+  chmod 700 "$HOME/.ssh"
+  ssh-keygen -t ed25519 -C "bld-league-devcontainer" -f "$SSH_KEY" -N ""
+  echo ""
+  echo "=========================================="
+  echo "New SSH key generated."
+  echo "Add the public key below to GitHub:"
+  echo "https://github.com/settings/ssh/new"
+  echo "=========================================="
+  cat "${SSH_KEY}.pub"
+  echo "=========================================="
+fi
+
+# Trust GitHub's host key
+ssh-keyscan -H github.com >> "$HOME/.ssh/known_hosts" 2>/dev/null
+
+# Use SSH for all GitHub git operations
+git config --global url."git@github.com:".insteadOf "https://github.com/"
+
+# Register GitHub MCP server
+if [ -n "$GITHUB_PERSONAL_ACCESS_TOKEN" ]; then
+  claude mcp add-json github \
+    "{\"type\":\"http\",\"url\":\"https://api.githubcopilot.com/mcp\",\"headers\":{\"Authorization\":\"Bearer $GITHUB_PERSONAL_ACCESS_TOKEN\"}}" \
+    --scope user 2>/dev/null || true
+fi

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -483,5 +483,6 @@ $RECYCLE.BIN/
 # Vim temporary swap files
 *.swp
 
-# Exclude claude config
-.claude/
+# Exclude claude config, but keep project-level commands
+.claude/*
+!.claude/commands/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,10 @@ dotnet ef migrations add MigrationName --project src/Infrastructure --startup-pr
 - WCA OAuth credentials (`ClientId`, `ClientSecret`) go under the `WCA` section — use user secrets in development (`UserSecretsId` is set in `Web.csproj`).
 - Database migrations are applied automatically on startup via `EnsureMigratedHelper`.
 
+## GitHub
+
+Repository: `kamilprzyb2/bld-league`. Use the GitHub MCP server for all GitHub operations (issues, PRs, branches) — do not use the `gh` CLI.
+
 ## Development Workflow
 
 ### Issues

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,7 @@ Avoid JavaScript by default. Prefer server-side form submissions and page reload
 | `Scramble` entity | `src/Domain/Entities/Scramble.cs` |
 | `RoundStanding` entity | `src/Domain/Entities/RoundStanding.cs` |
 | `LeagueSeasonStanding` entity | `src/Domain/Entities/LeagueSeasonStanding.cs` |
+| `PlayerRanking` entity | `src/Domain/Entities/PlayerRanking.cs` |
 | `User` entity | `src/Domain/Entities/User.cs` |
 | `SolveResult` value object | `src/Domain/ValueObjects/SolveResult.cs` |
 | `AverageCalculator` (Ao5 logic) | `src/Domain/Scoring/AverageCalculator.cs` |
@@ -188,6 +189,7 @@ Avoid JavaScript by default. Prefer server-side form submissions and page reload
 | `IRoundStandingRepository` | `src/Application/Abstractions/Repositories/IRoundStandingRepository.cs` |
 | `ILeagueSeasonStandingRepository` | `src/Application/Abstractions/Repositories/ILeagueSeasonStandingRepository.cs` |
 | `IUserRepository` | `src/Application/Abstractions/Repositories/IUserRepository.cs` |
+| `IPlayerRankingRepository` | `src/Application/Abstractions/Repositories/IPlayerRankingRepository.cs` |
 
 ### Application — commands (write operations, by feature)
 
@@ -202,6 +204,7 @@ Avoid JavaScript by default. Prefer server-side form submissions and page reload
 | User create/update/delete/import | `src/Application/Commands/Users/` |
 | Refresh round standings (single + refresh-all) | `src/Application/Commands/RoundStandings/Refresh/` and `RefreshAll/` |
 | Refresh season standings (single + refresh-all) | `src/Application/Commands/LeagueSeasonStandings/Refresh/` and `RefreshAll/` |
+| Refresh player rankings | `src/Application/Commands/PlayerRankings/Refresh/` |
 
 ### Application — queries (read operations, by feature)
 
@@ -213,6 +216,7 @@ Avoid JavaScript by default. Prefer server-side form submissions and page reload
 | Round queries + DTOs (incl. `ScrambleDto`, `RoundSummaryDto`) | `src/Application/Queries/Rounds/` |
 | Match queries + DTOs (incl. `SolveDto`, `MatchDetailsDto`, `MatchExportRowDto`) | `src/Application/Queries/Matches/` |
 | User queries + DTOs (incl. `LeagueSeasonUserDto` for roster queries) | `src/Application/Queries/Users/` |
+| Player rankings query + DTOs (`SingleRankingDto`, `AverageRankingDto`) | `src/Application/Queries/PlayerRankings/` |
 
 ### Infrastructure
 
@@ -252,6 +256,7 @@ Avoid JavaScript by default. Prefer server-side form submissions and page reload
 | View round results | `src/Web/Pages/Rounds/ViewRound.cshtml[.cs]` |
 | Match list | `src/Web/Pages/Matches/MatchList.cshtml[.cs]` |
 | Match detail | `src/Web/Pages/Matches/ViewMatch.cshtml[.cs]` |
+| Player rankings (single + average) | `src/Web/Pages/Rankings/Rankings.cshtml[.cs]` |
 | About / rules | `src/Web/Pages/About/About.cshtml[.cs]` |
 | Season 2 guidelines | `src/Web/Pages/About/Guidelines.cshtml[.cs]` |
 | Season 1 guidelines (archived) | `src/Web/Pages/About/GuidelinesSeason1.cshtml[.cs]` |

--- a/src/Application/Abstractions/Repositories/IPlayerRankingRepository.cs
+++ b/src/Application/Abstractions/Repositories/IPlayerRankingRepository.cs
@@ -1,0 +1,9 @@
+using BldLeague.Domain.Entities;
+
+namespace BldLeague.Application.Abstractions.Repositories;
+
+public interface IPlayerRankingRepository : IReadWriteRepository<PlayerRanking>
+{
+    Task<PlayerRanking?> GetByUserIdAsync(Guid userId);
+    Task<IReadOnlyCollection<PlayerRanking>> GetAllWithDetailsAsync();
+}

--- a/src/Application/Abstractions/Repositories/IPlayerRankingRepository.cs
+++ b/src/Application/Abstractions/Repositories/IPlayerRankingRepository.cs
@@ -4,6 +4,5 @@ namespace BldLeague.Application.Abstractions.Repositories;
 
 public interface IPlayerRankingRepository : IReadWriteRepository<PlayerRanking>
 {
-    Task<PlayerRanking?> GetByUserIdAsync(Guid userId);
     Task<IReadOnlyCollection<PlayerRanking>> GetAllWithDetailsAsync();
 }

--- a/src/Application/Abstractions/Repositories/IPlayerRankingRepository.cs
+++ b/src/Application/Abstractions/Repositories/IPlayerRankingRepository.cs
@@ -5,4 +5,6 @@ namespace BldLeague.Application.Abstractions.Repositories;
 public interface IPlayerRankingRepository : IReadWriteRepository<PlayerRanking>
 {
     Task<IReadOnlyCollection<PlayerRanking>> GetAllWithDetailsAsync();
+
+    Task DeleteAllAsync();
 }

--- a/src/Application/Abstractions/Repositories/IRoundRepository.cs
+++ b/src/Application/Abstractions/Repositories/IRoundRepository.cs
@@ -1,3 +1,4 @@
+using BldLeague.Application.Queries.Rounds.GetActiveFormUrl;
 using BldLeague.Application.Queries.Rounds.GetAll;
 using BldLeague.Application.Queries.Rounds.GetAllBySeasonId;
 using BldLeague.Application.Queries.Rounds.GetDetail;
@@ -12,4 +13,5 @@ public interface IRoundRepository : IReadWriteRepository<Round>
     Task<RoundSummaryDto?> GetSummaryByIdAsync(Guid id);
     Task<int?> GetLatestRoundNumberAsync();
     Task<RoundDetailDto?> GetRoundDetailAsync(Guid seasonId, int roundNumber);
+    Task<ActiveRoundFormDto?> GetActiveRoundFormUrlAsync(DateTime utcNow);
 }

--- a/src/Application/Abstractions/Repositories/IRoundStandingRepository.cs
+++ b/src/Application/Abstractions/Repositories/IRoundStandingRepository.cs
@@ -1,4 +1,5 @@
-﻿using BldLeague.Domain.Entities;
+﻿using BldLeague.Application.Commands.PlayerRankings.Refresh;
+using BldLeague.Domain.Entities;
 
 namespace BldLeague.Application.Abstractions.Repositories;
 
@@ -7,4 +8,8 @@ public interface IRoundStandingRepository : IReadWriteRepository<RoundStanding>
     Task<IReadOnlyCollection<RoundStanding>> GetRoundStandingsByRoundId(Guid roundId);
 
     Task<IReadOnlyCollection<(Guid, int)>> GetBonusPointsForLeagueSeasonAsync(Guid leagueId, Guid seasonId);
+
+    Task<IReadOnlyCollection<BestSinglePerUserDto>> GetBestSinglePerUserAsync();
+
+    Task<IReadOnlyCollection<BestAveragePerUserDto>> GetBestAveragePerUserAsync();
 }

--- a/src/Application/Abstractions/Repositories/IUnitOfWork.cs
+++ b/src/Application/Abstractions/Repositories/IUnitOfWork.cs
@@ -17,6 +17,7 @@ public interface IUnitOfWork
     IScrambleRepository ScrambleRepository { get; }
     IRoundStandingRepository RoundStandingRepository { get; }
     ILeagueSeasonStandingRepository LeagueSeasonStandingRepository { get; }
+    IPlayerRankingRepository PlayerRankingRepository { get; }
     
     /// <summary>
     /// Commits all changes made in the current unit of work as a single transaction asynchronously.

--- a/src/Application/Commands/PlayerRankings/Refresh/BestAveragePerUserDto.cs
+++ b/src/Application/Commands/PlayerRankings/Refresh/BestAveragePerUserDto.cs
@@ -1,0 +1,13 @@
+using BldLeague.Domain.ValueObjects;
+
+namespace BldLeague.Application.Commands.PlayerRankings.Refresh;
+
+public record BestAveragePerUserDto(
+    Guid UserId,
+    SolveResult Average,
+    Guid RoundId,
+    SolveResult Solve1,
+    SolveResult Solve2,
+    SolveResult Solve3,
+    SolveResult Solve4,
+    SolveResult Solve5);

--- a/src/Application/Commands/PlayerRankings/Refresh/BestSinglePerUserDto.cs
+++ b/src/Application/Commands/PlayerRankings/Refresh/BestSinglePerUserDto.cs
@@ -1,0 +1,5 @@
+using BldLeague.Domain.ValueObjects;
+
+namespace BldLeague.Application.Commands.PlayerRankings.Refresh;
+
+public record BestSinglePerUserDto(Guid UserId, SolveResult Best, Guid RoundId);

--- a/src/Application/Commands/PlayerRankings/Refresh/RefreshPlayerRankingsRequest.cs
+++ b/src/Application/Commands/PlayerRankings/Refresh/RefreshPlayerRankingsRequest.cs
@@ -1,0 +1,6 @@
+using BldLeague.Application.Common;
+using MediatR;
+
+namespace BldLeague.Application.Commands.PlayerRankings.Refresh;
+
+public class RefreshPlayerRankingsRequest : IRequest<CommandResult>;

--- a/src/Application/Commands/PlayerRankings/Refresh/RefreshPlayerRankingsRequestHandler.cs
+++ b/src/Application/Commands/PlayerRankings/Refresh/RefreshPlayerRankingsRequestHandler.cs
@@ -1,0 +1,156 @@
+using BldLeague.Application.Abstractions.Repositories;
+using BldLeague.Application.Common;
+using BldLeague.Domain.Entities;
+using MediatR;
+
+namespace BldLeague.Application.Commands.PlayerRankings.Refresh;
+
+public class RefreshPlayerRankingsRequestHandler(IUnitOfWork unitOfWork)
+    : IRequestHandler<RefreshPlayerRankingsRequest, CommandResult>
+{
+    public async Task<CommandResult> Handle(RefreshPlayerRankingsRequest request, CancellationToken cancellationToken)
+    {
+        var allStandings = await unitOfWork.RoundStandingRepository.GetAllAsync();
+
+        var byUser = allStandings.GroupBy(rs => rs.UserId).ToList();
+
+        var usersWithBestSingle = byUser
+            .Select(g =>
+            {
+                var validSingles = g.Where(rs => rs.Best.IsValid).ToList();
+                if (validSingles.Count == 0)
+                    return (UserId: g.Key, BestSingle: (BldLeague.Domain.ValueObjects.SolveResult?)null, SingleRoundId: (Guid?)null);
+                var best = validSingles.OrderBy(rs => rs.Best.Centiseconds).First();
+                return (UserId: g.Key, BestSingle: (BldLeague.Domain.ValueObjects.SolveResult?)best.Best, SingleRoundId: (Guid?)best.RoundId);
+            })
+            .ToList();
+
+        var usersWithBestAverage = byUser
+            .Select(g =>
+            {
+                var validAverages = g.Where(rs => rs.Average.IsValid).ToList();
+                if (validAverages.Count == 0)
+                    return (UserId: g.Key, BestAverage: (BldLeague.Domain.ValueObjects.SolveResult?)null, AverageRoundId: (Guid?)null, Standing: (RoundStanding?)null);
+                var best = validAverages.OrderBy(rs => rs.Average.Centiseconds).First();
+                return (UserId: g.Key, BestAverage: (BldLeague.Domain.ValueObjects.SolveResult?)best.Average, AverageRoundId: (Guid?)best.RoundId, Standing: (RoundStanding?)best);
+            })
+            .ToList();
+
+        // Assign single ranks (WCA tie logic)
+        var singleRanked = usersWithBestSingle
+            .Where(u => u.BestSingle.HasValue)
+            .OrderBy(u => u.BestSingle!.Value.Centiseconds)
+            .ToList();
+
+        var singleRanks = new Dictionary<Guid, int>();
+        int previousSingleCs = -1;
+        int previousSingleRank = 1;
+        for (int i = 0; i < singleRanked.Count; i++)
+        {
+            var cs = singleRanked[i].BestSingle!.Value.Centiseconds;
+            int rank;
+            if (i == 0)
+            {
+                rank = 1;
+            }
+            else if (cs == previousSingleCs)
+            {
+                rank = previousSingleRank;
+            }
+            else
+            {
+                rank = i + 1;
+            }
+            previousSingleCs = cs;
+            previousSingleRank = rank;
+            singleRanks[singleRanked[i].UserId] = rank;
+        }
+
+        // Assign average ranks (WCA tie logic)
+        var averageRanked = usersWithBestAverage
+            .Where(u => u.BestAverage.HasValue)
+            .OrderBy(u => u.BestAverage!.Value.Centiseconds)
+            .ToList();
+
+        var averageRanks = new Dictionary<Guid, int>();
+        int previousAverageCs = -1;
+        int previousAverageRank = 1;
+        for (int i = 0; i < averageRanked.Count; i++)
+        {
+            var cs = averageRanked[i].BestAverage!.Value.Centiseconds;
+            int rank;
+            if (i == 0)
+            {
+                rank = 1;
+            }
+            else if (cs == previousAverageCs)
+            {
+                rank = previousAverageRank;
+            }
+            else
+            {
+                rank = i + 1;
+            }
+            previousAverageCs = cs;
+            previousAverageRank = rank;
+            averageRanks[averageRanked[i].UserId] = rank;
+        }
+
+        // Build lookup maps
+        var singleMap = usersWithBestSingle.ToDictionary(u => u.UserId);
+        var averageMap = usersWithBestAverage.ToDictionary(u => u.UserId);
+
+        var allUserIds = byUser.Select(g => g.Key).ToList();
+
+        var toAdd = new List<PlayerRanking>();
+        var toUpdate = new List<PlayerRanking>();
+
+        foreach (var userId in allUserIds)
+        {
+            var ranking = await unitOfWork.PlayerRankingRepository.GetByUserIdAsync(userId);
+            bool isNew = ranking == null;
+            if (isNew)
+                ranking = PlayerRanking.Create(userId);
+
+            var singleEntry = singleMap[userId];
+            ranking!.BestSingle = singleEntry.BestSingle;
+            ranking.SingleRoundId = singleEntry.SingleRoundId;
+            ranking.SingleRank = singleRanks.TryGetValue(userId, out var sr) ? sr : null;
+
+            var avgEntry = averageMap[userId];
+            ranking.BestAverage = avgEntry.BestAverage;
+            ranking.AverageRoundId = avgEntry.AverageRoundId;
+            ranking.AverageRank = averageRanks.TryGetValue(userId, out var ar) ? ar : null;
+
+            if (avgEntry.Standing != null)
+            {
+                ranking.AverageSolve1 = avgEntry.Standing.Solve1;
+                ranking.AverageSolve2 = avgEntry.Standing.Solve2;
+                ranking.AverageSolve3 = avgEntry.Standing.Solve3;
+                ranking.AverageSolve4 = avgEntry.Standing.Solve4;
+                ranking.AverageSolve5 = avgEntry.Standing.Solve5;
+            }
+            else
+            {
+                ranking.AverageSolve1 = null;
+                ranking.AverageSolve2 = null;
+                ranking.AverageSolve3 = null;
+                ranking.AverageSolve4 = null;
+                ranking.AverageSolve5 = null;
+            }
+
+            if (isNew)
+                toAdd.Add(ranking);
+            else
+                toUpdate.Add(ranking);
+        }
+
+        foreach (var ranking in toUpdate)
+            unitOfWork.PlayerRankingRepository.Update(ranking);
+        await unitOfWork.PlayerRankingRepository.AddRangeAsync(toAdd);
+
+        await unitOfWork.SaveAsync();
+
+        return CommandResult.Ok("Zaktualizowano rankingi zawodników");
+    }
+}

--- a/src/Application/Commands/PlayerRankings/Refresh/RefreshPlayerRankingsRequestHandler.cs
+++ b/src/Application/Commands/PlayerRankings/Refresh/RefreshPlayerRankingsRequestHandler.cs
@@ -10,148 +10,66 @@ public class RefreshPlayerRankingsRequestHandler(IUnitOfWork unitOfWork)
 {
     public async Task<CommandResult> Handle(RefreshPlayerRankingsRequest request, CancellationToken cancellationToken)
     {
-        var allStandings = await unitOfWork.RoundStandingRepository.GetAllAsync();
+        var bestSingles = await unitOfWork.RoundStandingRepository.GetBestSinglePerUserAsync();
+        var bestAverages = await unitOfWork.RoundStandingRepository.GetBestAveragePerUserAsync();
 
-        var byUser = allStandings.GroupBy(rs => rs.UserId).ToList();
-
-        var usersWithBestSingle = byUser
-            .Select(g =>
-            {
-                var validSingles = g.Where(rs => rs.Best.IsValid).ToList();
-                if (validSingles.Count == 0)
-                    return (UserId: g.Key, BestSingle: (BldLeague.Domain.ValueObjects.SolveResult?)null, SingleRoundId: (Guid?)null);
-                var best = validSingles.OrderBy(rs => rs.Best.Centiseconds).First();
-                return (UserId: g.Key, BestSingle: (BldLeague.Domain.ValueObjects.SolveResult?)best.Best, SingleRoundId: (Guid?)best.RoundId);
-            })
-            .ToList();
-
-        var usersWithBestAverage = byUser
-            .Select(g =>
-            {
-                var validAverages = g.Where(rs => rs.Average.IsValid).ToList();
-                if (validAverages.Count == 0)
-                    return (UserId: g.Key, BestAverage: (BldLeague.Domain.ValueObjects.SolveResult?)null, AverageRoundId: (Guid?)null, Standing: (RoundStanding?)null);
-                var best = validAverages.OrderBy(rs => rs.Average.Centiseconds).First();
-                return (UserId: g.Key, BestAverage: (BldLeague.Domain.ValueObjects.SolveResult?)best.Average, AverageRoundId: (Guid?)best.RoundId, Standing: (RoundStanding?)best);
-            })
-            .ToList();
+        var averageByUserId = bestAverages.ToDictionary(a => a.UserId);
 
         // Assign single ranks (WCA tie logic)
-        var singleRanked = usersWithBestSingle
-            .Where(u => u.BestSingle.HasValue)
-            .OrderBy(u => u.BestSingle!.Value.Centiseconds)
-            .ToList();
-
+        var singleRanked = bestSingles.OrderBy(s => s.Best.Centiseconds).ToList();
         var singleRanks = new Dictionary<Guid, int>();
         int previousSingleCs = -1;
         int previousSingleRank = 1;
         for (int i = 0; i < singleRanked.Count; i++)
         {
-            var cs = singleRanked[i].BestSingle!.Value.Centiseconds;
-            int rank;
-            if (i == 0)
-            {
-                rank = 1;
-            }
-            else if (cs == previousSingleCs)
-            {
-                rank = previousSingleRank;
-            }
-            else
-            {
-                rank = i + 1;
-            }
+            var cs = singleRanked[i].Best.Centiseconds;
+            int rank = (i == 0) ? 1 : (cs == previousSingleCs ? previousSingleRank : i + 1);
             previousSingleCs = cs;
             previousSingleRank = rank;
             singleRanks[singleRanked[i].UserId] = rank;
         }
 
         // Assign average ranks (WCA tie logic)
-        var averageRanked = usersWithBestAverage
-            .Where(u => u.BestAverage.HasValue)
-            .OrderBy(u => u.BestAverage!.Value.Centiseconds)
-            .ToList();
-
+        var averageRanked = bestAverages.OrderBy(a => a.Average.Centiseconds).ToList();
         var averageRanks = new Dictionary<Guid, int>();
         int previousAverageCs = -1;
         int previousAverageRank = 1;
         for (int i = 0; i < averageRanked.Count; i++)
         {
-            var cs = averageRanked[i].BestAverage!.Value.Centiseconds;
-            int rank;
-            if (i == 0)
-            {
-                rank = 1;
-            }
-            else if (cs == previousAverageCs)
-            {
-                rank = previousAverageRank;
-            }
-            else
-            {
-                rank = i + 1;
-            }
+            var cs = averageRanked[i].Average.Centiseconds;
+            int rank = (i == 0) ? 1 : (cs == previousAverageCs ? previousAverageRank : i + 1);
             previousAverageCs = cs;
             previousAverageRank = rank;
             averageRanks[averageRanked[i].UserId] = rank;
         }
 
-        // Build lookup maps
-        var singleMap = usersWithBestSingle.ToDictionary(u => u.UserId);
-        var averageMap = usersWithBestAverage.ToDictionary(u => u.UserId);
-
-        var allUserIds = byUser.Select(g => g.Key).ToList();
-
-        var existingRankings = await unitOfWork.PlayerRankingRepository.GetAllAsync();
-        var existingByUserId = existingRankings.ToDictionary(r => r.UserId);
-
-        var toAdd = new List<PlayerRanking>();
-        var toUpdate = new List<PlayerRanking>();
-
-        foreach (var userId in allUserIds)
+        var rankings = bestSingles.Select(s =>
         {
-            bool isNew = !existingByUserId.TryGetValue(userId, out var ranking);
-            if (isNew)
-                ranking = PlayerRanking.Create(userId);
+            var ranking = PlayerRanking.Create(s.UserId);
+            ranking.BestSingle = s.Best;
+            ranking.SingleRoundId = s.RoundId;
+            ranking.SingleRank = singleRanks[s.UserId];
 
-            var singleEntry = singleMap[userId];
-            ranking.BestSingle = singleEntry.BestSingle;
-            ranking.SingleRoundId = singleEntry.SingleRoundId;
-            ranking.SingleRank = singleRanks.TryGetValue(userId, out var sr) ? sr : null;
-
-            var avgEntry = averageMap[userId];
-            ranking.BestAverage = avgEntry.BestAverage;
-            ranking.AverageRoundId = avgEntry.AverageRoundId;
-            ranking.AverageRank = averageRanks.TryGetValue(userId, out var ar) ? ar : null;
-
-            if (avgEntry.Standing != null)
+            if (averageByUserId.TryGetValue(s.UserId, out var avg))
             {
-                ranking.AverageSolve1 = avgEntry.Standing.Solve1;
-                ranking.AverageSolve2 = avgEntry.Standing.Solve2;
-                ranking.AverageSolve3 = avgEntry.Standing.Solve3;
-                ranking.AverageSolve4 = avgEntry.Standing.Solve4;
-                ranking.AverageSolve5 = avgEntry.Standing.Solve5;
-            }
-            else
-            {
-                ranking.AverageSolve1 = null;
-                ranking.AverageSolve2 = null;
-                ranking.AverageSolve3 = null;
-                ranking.AverageSolve4 = null;
-                ranking.AverageSolve5 = null;
+                ranking.BestAverage = avg.Average;
+                ranking.AverageRoundId = avg.RoundId;
+                ranking.AverageRank = averageRanks[s.UserId];
+                ranking.AverageSolve1 = avg.Solve1;
+                ranking.AverageSolve2 = avg.Solve2;
+                ranking.AverageSolve3 = avg.Solve3;
+                ranking.AverageSolve4 = avg.Solve4;
+                ranking.AverageSolve5 = avg.Solve5;
             }
 
-            if (isNew)
-                toAdd.Add(ranking);
-            else
-                toUpdate.Add(ranking);
-        }
+            return ranking;
+        }).ToList();
 
-        foreach (var ranking in toUpdate)
-            unitOfWork.PlayerRankingRepository.Update(ranking);
-        await unitOfWork.PlayerRankingRepository.AddRangeAsync(toAdd);
-
+        await unitOfWork.BeginTransactionAsync();
+        await unitOfWork.PlayerRankingRepository.DeleteAllAsync();
+        await unitOfWork.PlayerRankingRepository.AddRangeAsync(rankings);
         await unitOfWork.SaveAsync();
+        await unitOfWork.CommitTransactionAsync();
 
         return CommandResult.Ok("Zaktualizowano rankingi zawodników");
     }

--- a/src/Application/Commands/PlayerRankings/Refresh/RefreshPlayerRankingsRequestHandler.cs
+++ b/src/Application/Commands/PlayerRankings/Refresh/RefreshPlayerRankingsRequestHandler.cs
@@ -102,18 +102,20 @@ public class RefreshPlayerRankingsRequestHandler(IUnitOfWork unitOfWork)
 
         var allUserIds = byUser.Select(g => g.Key).ToList();
 
+        var existingRankings = await unitOfWork.PlayerRankingRepository.GetAllAsync();
+        var existingByUserId = existingRankings.ToDictionary(r => r.UserId);
+
         var toAdd = new List<PlayerRanking>();
         var toUpdate = new List<PlayerRanking>();
 
         foreach (var userId in allUserIds)
         {
-            var ranking = await unitOfWork.PlayerRankingRepository.GetByUserIdAsync(userId);
-            bool isNew = ranking == null;
+            bool isNew = !existingByUserId.TryGetValue(userId, out var ranking);
             if (isNew)
                 ranking = PlayerRanking.Create(userId);
 
             var singleEntry = singleMap[userId];
-            ranking!.BestSingle = singleEntry.BestSingle;
+            ranking.BestSingle = singleEntry.BestSingle;
             ranking.SingleRoundId = singleEntry.SingleRoundId;
             ranking.SingleRank = singleRanks.TryGetValue(userId, out var sr) ? sr : null;
 

--- a/src/Application/Commands/RoundStandings/Refresh/RefreshRoundStandingsRequestHandler.cs
+++ b/src/Application/Commands/RoundStandings/Refresh/RefreshRoundStandingsRequestHandler.cs
@@ -1,5 +1,6 @@
 using BldLeague.Application.Abstractions.Repositories;
 using BldLeague.Application.Commands.LeagueSeasonStandings.Refresh;
+using BldLeague.Application.Commands.PlayerRankings.Refresh;
 using BldLeague.Application.Common;
 using BldLeague.Domain.Entities;
 using BldLeague.Domain.ValueObjects;
@@ -151,6 +152,8 @@ public class RefreshRoundStandingsRequestHandler(IUnitOfWork unitOfWork, ISender
         var leagueSeasons = await unitOfWork.LeagueSeasonRepository.GetLeagueSeasonsForSeasonIdAsync(round.SeasonId);
         foreach (var ls in leagueSeasons)
             await sender.Send(new RefreshLeagueSeasonStandingsRequest(ls.LeagueSeasonId), cancellationToken);
+
+        await sender.Send(new RefreshPlayerRankingsRequest(), cancellationToken);
 
         return CommandResult.Ok("Zaktualizowano klasyfikację kolejki");
     }

--- a/src/Application/Commands/Rounds/Create/CreateRoundRequest.cs
+++ b/src/Application/Commands/Rounds/Create/CreateRoundRequest.cs
@@ -20,6 +20,10 @@ public class CreateRoundRequest : IRequest<CommandResult>, IValidatableObject
     [RequiredPl] [DataType(DataType.Date)]
     public DateTime EndDate { get; set; }
 
+    [Url]
+    [StringLength(2048)]
+    public string? SubmissionFormUrl { get; set; }
+
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
         if (EndDate <= StartDate)

--- a/src/Application/Commands/Rounds/Create/CreateRoundRequestHandler.cs
+++ b/src/Application/Commands/Rounds/Create/CreateRoundRequestHandler.cs
@@ -34,7 +34,7 @@ public class CreateRoundRequestHandler(IUnitOfWork unitOfWork)
                 "Kolejka o podanym numerze już istnieje");
         }
 
-        var round = Round.Create(request.SeasonId, request.RoundNumber, request.StartDate, request.EndDate);
+        var round = Round.Create(request.SeasonId, request.RoundNumber, request.StartDate, request.EndDate, request.SubmissionFormUrl);
         await unitOfWork.RoundRepository.AddAsync(round);
         await unitOfWork.SaveAsync();
         return CommandResult.Ok("Kolejka została utworzona");

--- a/src/Application/Commands/Rounds/Update/UpdateRoundRequest.cs
+++ b/src/Application/Commands/Rounds/Update/UpdateRoundRequest.cs
@@ -22,6 +22,10 @@ public class UpdateRoundRequest : IRequest<CommandResult>, IValidatableObject
     [RequiredPl] [DataType(DataType.Date)]
     public DateTime EndDate { get; set; }
 
+    [Url]
+    [StringLength(2048)]
+    public string? SubmissionFormUrl { get; set; }
+
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
         if (EndDate <= StartDate)

--- a/src/Application/Commands/Rounds/Update/UpdateRoundRequestHandler.cs
+++ b/src/Application/Commands/Rounds/Update/UpdateRoundRequestHandler.cs
@@ -47,6 +47,7 @@ public class UpdateRoundRequestHandler(IUnitOfWork unitOfWork)
         round.RoundNumber = request.RoundNumber;
         round.StartDate = request.StartDate;
         round.EndDate = request.EndDate;
+        round.SubmissionFormUrl = request.SubmissionFormUrl;
 
         unitOfWork.RoundRepository.Update(round);
         await unitOfWork.SaveAsync();

--- a/src/Application/Queries/PlayerRankings/GetPlayerRankings/AverageRankingDto.cs
+++ b/src/Application/Queries/PlayerRankings/GetPlayerRankings/AverageRankingDto.cs
@@ -1,0 +1,15 @@
+using BldLeague.Domain.ValueObjects;
+
+namespace BldLeague.Application.Queries.PlayerRankings.GetPlayerRankings;
+
+public record AverageRankingDto(
+    int AverageRank,
+    string FullName,
+    SolveResult BestAverage,
+    string RoundLabel,
+    SolveResult Solve1,
+    SolveResult Solve2,
+    SolveResult Solve3,
+    SolveResult Solve4,
+    SolveResult Solve5
+);

--- a/src/Application/Queries/PlayerRankings/GetPlayerRankings/GetPlayerRankingsRequest.cs
+++ b/src/Application/Queries/PlayerRankings/GetPlayerRankings/GetPlayerRankingsRequest.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace BldLeague.Application.Queries.PlayerRankings.GetPlayerRankings;
+
+public class GetPlayerRankingsRequest : IRequest<GetPlayerRankingsResponse>;

--- a/src/Application/Queries/PlayerRankings/GetPlayerRankings/GetPlayerRankingsRequestHandler.cs
+++ b/src/Application/Queries/PlayerRankings/GetPlayerRankings/GetPlayerRankingsRequestHandler.cs
@@ -1,0 +1,42 @@
+using BldLeague.Application.Abstractions.Repositories;
+using MediatR;
+
+namespace BldLeague.Application.Queries.PlayerRankings.GetPlayerRankings;
+
+public class GetPlayerRankingsRequestHandler(IUnitOfWork unitOfWork)
+    : IRequestHandler<GetPlayerRankingsRequest, GetPlayerRankingsResponse>
+{
+    public async Task<GetPlayerRankingsResponse> Handle(GetPlayerRankingsRequest request, CancellationToken cancellationToken)
+    {
+        var rankings = await unitOfWork.PlayerRankingRepository.GetAllWithDetailsAsync();
+
+        var singleRankings = rankings
+            .Where(r => r.SingleRank.HasValue && r.BestSingle.HasValue)
+            .OrderBy(r => r.SingleRank!.Value)
+            .Select(r => new SingleRankingDto(
+                r.SingleRank!.Value,
+                r.User.FullName,
+                r.BestSingle!.Value,
+                $"Sezon {r.SingleRound!.Season.SeasonNumber} Kolejka {r.SingleRound.RoundNumber}"
+            ))
+            .ToList();
+
+        var averageRankings = rankings
+            .Where(r => r.AverageRank.HasValue && r.BestAverage.HasValue)
+            .OrderBy(r => r.AverageRank!.Value)
+            .Select(r => new AverageRankingDto(
+                r.AverageRank!.Value,
+                r.User.FullName,
+                r.BestAverage!.Value,
+                $"Sezon {r.AverageRound!.Season.SeasonNumber} Kolejka {r.AverageRound.RoundNumber}",
+                r.AverageSolve1!.Value,
+                r.AverageSolve2!.Value,
+                r.AverageSolve3!.Value,
+                r.AverageSolve4!.Value,
+                r.AverageSolve5!.Value
+            ))
+            .ToList();
+
+        return new GetPlayerRankingsResponse(singleRankings, averageRankings);
+    }
+}

--- a/src/Application/Queries/PlayerRankings/GetPlayerRankings/GetPlayerRankingsResponse.cs
+++ b/src/Application/Queries/PlayerRankings/GetPlayerRankings/GetPlayerRankingsResponse.cs
@@ -1,0 +1,6 @@
+namespace BldLeague.Application.Queries.PlayerRankings.GetPlayerRankings;
+
+public record GetPlayerRankingsResponse(
+    IReadOnlyCollection<SingleRankingDto> SingleRankings,
+    IReadOnlyCollection<AverageRankingDto> AverageRankings
+);

--- a/src/Application/Queries/PlayerRankings/GetPlayerRankings/SingleRankingDto.cs
+++ b/src/Application/Queries/PlayerRankings/GetPlayerRankings/SingleRankingDto.cs
@@ -1,0 +1,10 @@
+using BldLeague.Domain.ValueObjects;
+
+namespace BldLeague.Application.Queries.PlayerRankings.GetPlayerRankings;
+
+public record SingleRankingDto(
+    int SingleRank,
+    string FullName,
+    SolveResult BestSingle,
+    string RoundLabel
+);

--- a/src/Application/Queries/Rounds/GetActiveFormUrl/ActiveRoundFormDto.cs
+++ b/src/Application/Queries/Rounds/GetActiveFormUrl/ActiveRoundFormDto.cs
@@ -1,0 +1,6 @@
+namespace BldLeague.Application.Queries.Rounds.GetActiveFormUrl;
+
+/// <summary>
+/// Contains the submission form URL and round name for the currently active round.
+/// </summary>
+public record ActiveRoundFormDto(string Url, string RoundName);

--- a/src/Application/Queries/Rounds/GetActiveFormUrl/GetActiveRoundFormUrlRequest.cs
+++ b/src/Application/Queries/Rounds/GetActiveFormUrl/GetActiveRoundFormUrlRequest.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace BldLeague.Application.Queries.Rounds.GetActiveFormUrl;
+
+/// <summary>
+/// Request to get the submission form URL for the currently active round (StartDate &lt;= UtcNow &lt;= EndDate).
+/// Returns null when no round is active or the active round has no form URL set.
+/// </summary>
+public class GetActiveRoundFormUrlRequest : IRequest<ActiveRoundFormDto?>;

--- a/src/Application/Queries/Rounds/GetActiveFormUrl/GetActiveRoundFormUrlRequestHandler.cs
+++ b/src/Application/Queries/Rounds/GetActiveFormUrl/GetActiveRoundFormUrlRequestHandler.cs
@@ -1,0 +1,16 @@
+using BldLeague.Application.Abstractions.Repositories;
+using MediatR;
+
+namespace BldLeague.Application.Queries.Rounds.GetActiveFormUrl;
+
+/// <summary>
+/// Handles retrieving the submission form URL for the currently active round.
+/// </summary>
+public class GetActiveRoundFormUrlRequestHandler(IUnitOfWork unitOfWork)
+    : IRequestHandler<GetActiveRoundFormUrlRequest, ActiveRoundFormDto?>
+{
+    public async Task<ActiveRoundFormDto?> Handle(GetActiveRoundFormUrlRequest request, CancellationToken cancellationToken)
+    {
+        return await unitOfWork.RoundRepository.GetActiveRoundFormUrlAsync(DateTime.UtcNow);
+    }
+}

--- a/src/Application/Queries/Rounds/GetAllBySeasonId/RoundSummaryDto.cs
+++ b/src/Application/Queries/Rounds/GetAllBySeasonId/RoundSummaryDto.cs
@@ -3,7 +3,7 @@ namespace BldLeague.Application.Queries.Rounds.GetAllBySeasonId;
 /// <summary>
 /// Summary data transfer object for a round, used in the public-facing round selector and standings pages.
 /// </summary>
-public record RoundSummaryDto(Guid Id, Guid SeasonId, int RoundNumber, DateTime StartDate, DateTime EndDate)
+public record RoundSummaryDto(Guid Id, Guid SeasonId, int RoundNumber, DateTime StartDate, DateTime EndDate, string? SubmissionFormUrl = null)
 {
     public string RoundName => $"Kolejka {RoundNumber}";
 }

--- a/src/Domain/Entities/PlayerRanking.cs
+++ b/src/Domain/Entities/PlayerRanking.cs
@@ -1,0 +1,100 @@
+using BldLeague.Domain.Interfaces;
+using BldLeague.Domain.ValueObjects;
+
+namespace BldLeague.Domain.Entities;
+
+/// <summary>
+/// Represents the all-time ranking for a player, storing their best single and best average.
+/// </summary>
+public class PlayerRanking : IIdentifiable
+{
+    /// <inheritdoc />
+    public Guid Id { get; init; }
+
+    /// <summary>
+    /// Associated user ID.
+    /// </summary>
+    public Guid UserId { get; set; }
+
+    /// <summary>
+    /// Associated user.
+    /// </summary>
+    public User User { get; set; } = null!;
+
+    /// <summary>
+    /// Player's best single result across all rounds. Null if no valid single exists.
+    /// </summary>
+    public SolveResult? BestSingle { get; set; }
+
+    /// <summary>
+    /// Player's rank by best single. Null if excluded from single ranking.
+    /// </summary>
+    public int? SingleRank { get; set; }
+
+    /// <summary>
+    /// Round ID where the best single was achieved. Null if no valid single exists.
+    /// </summary>
+    public Guid? SingleRoundId { get; set; }
+
+    /// <summary>
+    /// Round where the best single was achieved.
+    /// </summary>
+    public Round? SingleRound { get; set; }
+
+    /// <summary>
+    /// Player's best average result across all rounds. Null if no valid average exists.
+    /// </summary>
+    public SolveResult? BestAverage { get; set; }
+
+    /// <summary>
+    /// Player's rank by best average. Null if excluded from average ranking.
+    /// </summary>
+    public int? AverageRank { get; set; }
+
+    /// <summary>
+    /// Round ID where the best average was achieved. Null if no valid average exists.
+    /// </summary>
+    public Guid? AverageRoundId { get; set; }
+
+    /// <summary>
+    /// Round where the best average was achieved.
+    /// </summary>
+    public Round? AverageRound { get; set; }
+
+    /// <summary>
+    /// Solve 1 from the round where the best average was achieved.
+    /// </summary>
+    public SolveResult? AverageSolve1 { get; set; }
+
+    /// <summary>
+    /// Solve 2 from the round where the best average was achieved.
+    /// </summary>
+    public SolveResult? AverageSolve2 { get; set; }
+
+    /// <summary>
+    /// Solve 3 from the round where the best average was achieved.
+    /// </summary>
+    public SolveResult? AverageSolve3 { get; set; }
+
+    /// <summary>
+    /// Solve 4 from the round where the best average was achieved.
+    /// </summary>
+    public SolveResult? AverageSolve4 { get; set; }
+
+    /// <summary>
+    /// Solve 5 from the round where the best average was achieved.
+    /// </summary>
+    public SolveResult? AverageSolve5 { get; set; }
+
+    /// <summary>
+    /// Factory method for creating a new <see cref="PlayerRanking"/> for a given user.
+    /// </summary>
+    /// <param name="userId">The associated user ID.</param>
+    /// <returns>A new <see cref="PlayerRanking"/> with all nullable ranking fields set to null.</returns>
+    public static PlayerRanking Create(Guid userId)
+        => new PlayerRanking
+        {
+            Id = Guid.CreateVersion7(),
+            UserId = userId
+        };
+}

--- a/src/Domain/Entities/Round.cs
+++ b/src/Domain/Entities/Round.cs
@@ -53,6 +53,12 @@ public class Round : IIdentifiable
     public ICollection<Match> Matches { get; set; } = new List<Match>();
     
     /// <summary>
+    /// Optional URL for the external result submission form (e.g. Google Forms).
+    /// Temporary — will be removed once in-app submission is implemented.
+    /// </summary>
+    public string? SubmissionFormUrl { get; set; }
+
+    /// <summary>
     /// Scrambles belonging to the round.
     /// </summary>
     public ICollection<Scramble> Scrambles { get; set; } = new List<Scramble>();
@@ -69,14 +75,16 @@ public class Round : IIdentifiable
     /// <param name="roundNumber"></param>
     /// <param name="startDate"></param>
     /// <param name="endDate"></param>
+    /// <param name="submissionFormUrl"></param>
     /// <returns></returns>
-    public static Round Create(Guid seasonId, int roundNumber, DateTime startDate, DateTime endDate)
+    public static Round Create(Guid seasonId, int roundNumber, DateTime startDate, DateTime endDate, string? submissionFormUrl = null)
         => new Round
         {
             Id = Guid.CreateVersion7(),
             SeasonId = seasonId,
             RoundNumber = roundNumber,
             StartDate = startDate,
-            EndDate = endDate
+            EndDate = endDate,
+            SubmissionFormUrl = submissionFormUrl
         };
 }

--- a/src/Domain/Entities/User.cs
+++ b/src/Domain/Entities/User.cs
@@ -66,6 +66,11 @@ public sealed class User : IIdentifiable
     /// League season standings of the user.
     /// </summary>
     public ICollection<LeagueSeasonStanding> LeagueSeasonStandings { get; set; } = new List<LeagueSeasonStanding>();
+
+    /// <summary>
+    /// Player ranking for this user.
+    /// </summary>
+    public PlayerRanking? PlayerRanking { get; set; }
     
     /// <summary>
     /// User factory method.

--- a/src/Infrastructure/Configuration/PlayerRankingConfiguration.cs
+++ b/src/Infrastructure/Configuration/PlayerRankingConfiguration.cs
@@ -1,0 +1,78 @@
+using BldLeague.Domain.Entities;
+using BldLeague.Domain.ValueObjects;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace BldLeague.Infrastructure.Configuration;
+
+public class PlayerRankingConfiguration : IEntityTypeConfiguration<PlayerRanking>
+{
+    public void Configure(EntityTypeBuilder<PlayerRanking> b)
+    {
+        b.ToTable("PlayerRankings");
+        b.HasKey(pr => pr.Id);
+        b.Property(pr => pr.Id).ValueGeneratedNever();
+
+        b.HasIndex(pr => pr.UserId).IsUnique();
+
+        b.HasOne(pr => pr.User)
+            .WithOne(u => u.PlayerRanking)
+            .HasForeignKey<PlayerRanking>(pr => pr.UserId)
+            .IsRequired()
+            .OnDelete(DeleteBehavior.Cascade);
+
+        b.HasOne(pr => pr.SingleRound)
+            .WithMany()
+            .HasForeignKey(pr => pr.SingleRoundId)
+            .IsRequired(false)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        b.HasOne(pr => pr.AverageRound)
+            .WithMany()
+            .HasForeignKey(pr => pr.AverageRoundId)
+            .IsRequired(false)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        b.Property(pr => pr.BestSingle)
+            .HasConversion(
+                v => v != null ? (int?)v.Value.Centiseconds : null,
+                v => v.HasValue ? SolveResult.FromCentiseconds(v.Value) : (SolveResult?)null)
+            .IsRequired(false);
+
+        b.Property(pr => pr.BestAverage)
+            .HasConversion(
+                v => v != null ? (int?)v.Value.Centiseconds : null,
+                v => v.HasValue ? SolveResult.FromCentiseconds(v.Value) : (SolveResult?)null)
+            .IsRequired(false);
+
+        b.Property(pr => pr.AverageSolve1)
+            .HasConversion(
+                v => v != null ? (int?)v.Value.Centiseconds : null,
+                v => v.HasValue ? SolveResult.FromCentiseconds(v.Value) : (SolveResult?)null)
+            .IsRequired(false);
+
+        b.Property(pr => pr.AverageSolve2)
+            .HasConversion(
+                v => v != null ? (int?)v.Value.Centiseconds : null,
+                v => v.HasValue ? SolveResult.FromCentiseconds(v.Value) : (SolveResult?)null)
+            .IsRequired(false);
+
+        b.Property(pr => pr.AverageSolve3)
+            .HasConversion(
+                v => v != null ? (int?)v.Value.Centiseconds : null,
+                v => v.HasValue ? SolveResult.FromCentiseconds(v.Value) : (SolveResult?)null)
+            .IsRequired(false);
+
+        b.Property(pr => pr.AverageSolve4)
+            .HasConversion(
+                v => v != null ? (int?)v.Value.Centiseconds : null,
+                v => v.HasValue ? SolveResult.FromCentiseconds(v.Value) : (SolveResult?)null)
+            .IsRequired(false);
+
+        b.Property(pr => pr.AverageSolve5)
+            .HasConversion(
+                v => v != null ? (int?)v.Value.Centiseconds : null,
+                v => v.HasValue ? SolveResult.FromCentiseconds(v.Value) : (SolveResult?)null)
+            .IsRequired(false);
+    }
+}

--- a/src/Infrastructure/Configuration/RoundConfiguration.cs
+++ b/src/Infrastructure/Configuration/RoundConfiguration.cs
@@ -20,9 +20,11 @@ public class RoundConfiguration : IEntityTypeConfiguration<Round>
         b.Property(r => r.RoundNumber).IsRequired();
         
         b.Property(r => r.StartDate).IsRequired();
-        
+
         b.Property(r => r.EndDate).IsRequired();
-        
+
+        b.Property(r => r.SubmissionFormUrl).HasMaxLength(2048);
+
         b.HasIndex(r => new { r.SeasonId, r.RoundNumber })
             .IsUnique();
     }

--- a/src/Infrastructure/Context/AppDbContext.cs
+++ b/src/Infrastructure/Context/AppDbContext.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using BldLeague.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
 
 namespace BldLeague.Infrastructure.Context;
 
@@ -7,7 +8,9 @@ public class AppDbContext : DbContext
 {
     /// <inheritdoc />
     public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
-    
+
+    public DbSet<PlayerRanking> PlayerRankings => Set<PlayerRanking>();
+
     /// <inheritdoc />
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/Infrastructure/Migrations/20260408185620_AddRoundSubmissionFormUrl.Designer.cs
+++ b/src/Infrastructure/Migrations/20260408185620_AddRoundSubmissionFormUrl.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BldLeague.Infrastructure.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BldLeague.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260408185620_AddRoundSubmissionFormUrl")]
+    partial class AddRoundSubmissionFormUrl
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20260408185620_AddRoundSubmissionFormUrl.cs
+++ b/src/Infrastructure/Migrations/20260408185620_AddRoundSubmissionFormUrl.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BldLeague.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRoundSubmissionFormUrl : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "submission_form_url",
+                table: "rounds",
+                type: "character varying(2048)",
+                maxLength: 2048,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "submission_form_url",
+                table: "rounds");
+        }
+    }
+}

--- a/src/Infrastructure/Migrations/20260411140500_AddPlayerRankings.Designer.cs
+++ b/src/Infrastructure/Migrations/20260411140500_AddPlayerRankings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BldLeague.Infrastructure.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BldLeague.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260411140500_AddPlayerRankings")]
+    partial class AddPlayerRankings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20260411140500_AddPlayerRankings.cs
+++ b/src/Infrastructure/Migrations/20260411140500_AddPlayerRankings.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BldLeague.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPlayerRankings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PlayerRankings",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    best_single = table.Column<int>(type: "integer", nullable: true),
+                    single_rank = table.Column<int>(type: "integer", nullable: true),
+                    single_round_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    best_average = table.Column<int>(type: "integer", nullable: true),
+                    average_rank = table.Column<int>(type: "integer", nullable: true),
+                    average_round_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    average_solve1 = table.Column<int>(type: "integer", nullable: true),
+                    average_solve2 = table.Column<int>(type: "integer", nullable: true),
+                    average_solve3 = table.Column<int>(type: "integer", nullable: true),
+                    average_solve4 = table.Column<int>(type: "integer", nullable: true),
+                    average_solve5 = table.Column<int>(type: "integer", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_player_rankings", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_player_rankings_round_average_round_id",
+                        column: x => x.average_round_id,
+                        principalTable: "rounds",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_player_rankings_round_single_round_id",
+                        column: x => x.single_round_id,
+                        principalTable: "rounds",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "fk_player_rankings_user_user_id",
+                        column: x => x.user_id,
+                        principalTable: "users",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_player_rankings_average_round_id",
+                table: "PlayerRankings",
+                column: "average_round_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_player_rankings_single_round_id",
+                table: "PlayerRankings",
+                column: "single_round_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_player_rankings_user_id",
+                table: "PlayerRankings",
+                column: "user_id",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PlayerRankings");
+        }
+    }
+}

--- a/src/Infrastructure/Repositories/PlayerRankingRepository.cs
+++ b/src/Infrastructure/Repositories/PlayerRankingRepository.cs
@@ -8,12 +8,6 @@ namespace BldLeague.Infrastructure.Repositories;
 public class PlayerRankingRepository(AppDbContext context)
     : ReadWriteRepositoryBase<PlayerRanking>(context), IPlayerRankingRepository
 {
-    public async Task<PlayerRanking?> GetByUserIdAsync(Guid userId)
-    {
-        return await DbSet
-            .FirstOrDefaultAsync(pr => pr.UserId == userId);
-    }
-
     public async Task<IReadOnlyCollection<PlayerRanking>> GetAllWithDetailsAsync()
     {
         return await DbSet

--- a/src/Infrastructure/Repositories/PlayerRankingRepository.cs
+++ b/src/Infrastructure/Repositories/PlayerRankingRepository.cs
@@ -18,4 +18,9 @@ public class PlayerRankingRepository(AppDbContext context)
                 .ThenInclude(r => r!.Season)
             .ToListAsync();
     }
+
+    public async Task DeleteAllAsync()
+    {
+        await DbSet.ExecuteDeleteAsync();
+    }
 }

--- a/src/Infrastructure/Repositories/PlayerRankingRepository.cs
+++ b/src/Infrastructure/Repositories/PlayerRankingRepository.cs
@@ -1,0 +1,27 @@
+using BldLeague.Application.Abstractions.Repositories;
+using BldLeague.Domain.Entities;
+using BldLeague.Infrastructure.Context;
+using Microsoft.EntityFrameworkCore;
+
+namespace BldLeague.Infrastructure.Repositories;
+
+public class PlayerRankingRepository(AppDbContext context)
+    : ReadWriteRepositoryBase<PlayerRanking>(context), IPlayerRankingRepository
+{
+    public async Task<PlayerRanking?> GetByUserIdAsync(Guid userId)
+    {
+        return await DbSet
+            .FirstOrDefaultAsync(pr => pr.UserId == userId);
+    }
+
+    public async Task<IReadOnlyCollection<PlayerRanking>> GetAllWithDetailsAsync()
+    {
+        return await DbSet
+            .Include(pr => pr.User)
+            .Include(pr => pr.SingleRound)
+                .ThenInclude(r => r!.Season)
+            .Include(pr => pr.AverageRound)
+                .ThenInclude(r => r!.Season)
+            .ToListAsync();
+    }
+}

--- a/src/Infrastructure/Repositories/RoundRepository.cs
+++ b/src/Infrastructure/Repositories/RoundRepository.cs
@@ -1,4 +1,5 @@
 using BldLeague.Application.Abstractions.Repositories;
+using BldLeague.Application.Queries.Rounds.GetActiveFormUrl;
 using BldLeague.Application.Queries.Rounds.GetAll;
 using BldLeague.Application.Queries.Rounds.GetAllBySeasonId;
 using BldLeague.Application.Queries.Rounds.GetDetail;
@@ -16,7 +17,7 @@ public class RoundRepository(AppDbContext context) :
         => await DbSet
             .Where(r => r.SeasonId == seasonId)
             .OrderBy(r => r.RoundNumber)
-            .Select(r => new RoundSummaryDto(r.Id, r.SeasonId, r.RoundNumber, r.StartDate, r.EndDate))
+            .Select(r => new RoundSummaryDto(r.Id, r.SeasonId, r.RoundNumber, r.StartDate, r.EndDate, r.SubmissionFormUrl))
             .ToListAsync();
 
     public async Task<IReadOnlyCollection<RoundAdminSummaryDto>> GetAllRoundSummariesAsync()
@@ -29,13 +30,24 @@ public class RoundRepository(AppDbContext context) :
     public async Task<RoundSummaryDto?> GetSummaryByIdAsync(Guid id)
         => await DbSet
             .Where(r => r.Id == id)
-            .Select(r => new RoundSummaryDto(r.Id, r.SeasonId, r.RoundNumber, r.StartDate, r.EndDate))
+            .Select(r => new RoundSummaryDto(r.Id, r.SeasonId, r.RoundNumber, r.StartDate, r.EndDate, r.SubmissionFormUrl))
             .FirstOrDefaultAsync();
 
     public async Task<int?> GetLatestRoundNumberAsync()
         => await DbSet
             .Select(r => (int?)r.RoundNumber)
             .MaxAsync();
+
+    public async Task<ActiveRoundFormDto?> GetActiveRoundFormUrlAsync(DateTime utcNow)
+    {
+        var todayStart = utcNow.Date;
+        var tomorrowStart = todayStart.AddDays(1);
+        return await DbSet
+            .Where(r => r.StartDate < tomorrowStart && r.EndDate >= todayStart
+                        && r.SubmissionFormUrl != null && r.SubmissionFormUrl != "")
+            .Select(r => new ActiveRoundFormDto(r.SubmissionFormUrl!, "Kolejka " + r.RoundNumber))
+            .FirstOrDefaultAsync();
+    }
 
     public async Task<RoundDetailDto?> GetRoundDetailAsync(Guid seasonId, int roundNumber)
         => await DbSet

--- a/src/Infrastructure/Repositories/RoundStandingRepository.cs
+++ b/src/Infrastructure/Repositories/RoundStandingRepository.cs
@@ -1,5 +1,7 @@
 ﻿using BldLeague.Application.Abstractions.Repositories;
+using BldLeague.Application.Commands.PlayerRankings.Refresh;
 using BldLeague.Domain.Entities;
+using BldLeague.Domain.ValueObjects;
 using BldLeague.Infrastructure.Context;
 using Microsoft.EntityFrameworkCore;
 
@@ -27,4 +29,41 @@ public class RoundStandingRepository(AppDbContext context)
             .ToListAsync();
     }
 
+    public async Task<IReadOnlyCollection<BestSinglePerUserDto>> GetBestSinglePerUserAsync()
+    {
+        var rows = await DbSet
+            .Where(rs => rs.Best >= (SolveResult)0
+                && !DbSet.Any(other =>
+                    other.UserId == rs.UserId
+                    && other.Best >= (SolveResult)0
+                    && other.Best < rs.Best))
+            .Select(rs => new BestSinglePerUserDto(rs.UserId, rs.Best, rs.RoundId))
+            .ToListAsync();
+
+        // Deduplicate in case of exact ties: pick one row per user arbitrarily
+        return rows
+            .GroupBy(dto => dto.UserId)
+            .Select(g => g.First())
+            .ToList();
+    }
+
+    public async Task<IReadOnlyCollection<BestAveragePerUserDto>> GetBestAveragePerUserAsync()
+    {
+        var rows = await DbSet
+            .Where(rs => rs.Average >= (SolveResult)0
+                && !DbSet.Any(other =>
+                    other.UserId == rs.UserId
+                    && other.Average >= (SolveResult)0
+                    && other.Average < rs.Average))
+            .Select(rs => new BestAveragePerUserDto(
+                rs.UserId, rs.Average, rs.RoundId,
+                rs.Solve1, rs.Solve2, rs.Solve3, rs.Solve4, rs.Solve5))
+            .ToListAsync();
+
+        // Deduplicate in case of exact ties: pick one row per user arbitrarily
+        return rows
+            .GroupBy(dto => dto.UserId)
+            .Select(g => g.First())
+            .ToList();
+    }
 }

--- a/src/Infrastructure/Repositories/RoundStandingRepository.cs
+++ b/src/Infrastructure/Repositories/RoundStandingRepository.cs
@@ -31,39 +31,23 @@ public class RoundStandingRepository(AppDbContext context)
 
     public async Task<IReadOnlyCollection<BestSinglePerUserDto>> GetBestSinglePerUserAsync()
     {
-        var rows = await DbSet
-            .Where(rs => rs.Best >= (SolveResult)0
-                && !DbSet.Any(other =>
-                    other.UserId == rs.UserId
-                    && other.Best >= (SolveResult)0
-                    && other.Best < rs.Best))
+        return await DbSet
+            .Where(rs => rs.Best >= (SolveResult)0)
+            .GroupBy(rs => rs.UserId)
+            .Select(g => g.OrderBy(rs => rs.Best).First())
             .Select(rs => new BestSinglePerUserDto(rs.UserId, rs.Best, rs.RoundId))
             .ToListAsync();
-
-        // Deduplicate in case of exact ties: pick one row per user arbitrarily
-        return rows
-            .GroupBy(dto => dto.UserId)
-            .Select(g => g.First())
-            .ToList();
     }
 
     public async Task<IReadOnlyCollection<BestAveragePerUserDto>> GetBestAveragePerUserAsync()
     {
-        var rows = await DbSet
-            .Where(rs => rs.Average >= (SolveResult)0
-                && !DbSet.Any(other =>
-                    other.UserId == rs.UserId
-                    && other.Average >= (SolveResult)0
-                    && other.Average < rs.Average))
+        return await DbSet
+            .Where(rs => rs.Average >= (SolveResult)0)
+            .GroupBy(rs => rs.UserId)
+            .Select(g => g.OrderBy(rs => rs.Average).First())
             .Select(rs => new BestAveragePerUserDto(
                 rs.UserId, rs.Average, rs.RoundId,
                 rs.Solve1, rs.Solve2, rs.Solve3, rs.Solve4, rs.Solve5))
             .ToListAsync();
-
-        // Deduplicate in case of exact ties: pick one row per user arbitrarily
-        return rows
-            .GroupBy(dto => dto.UserId)
-            .Select(g => g.First())
-            .ToList();
     }
 }

--- a/src/Infrastructure/Repositories/RoundStandingRepository.cs
+++ b/src/Infrastructure/Repositories/RoundStandingRepository.cs
@@ -22,8 +22,9 @@ public class RoundStandingRepository(AppDbContext context)
             .Where(rs => rs.LeagueId == leagueId && rs.Round.SeasonId == seasonId)
             .GroupBy(rs => rs.UserId)
             .Select(g => new ValueTuple<Guid, int>(
-                g.Key, 
+                g.Key,
                 g.Sum(rs=>rs.Points)))
             .ToListAsync();
     }
+
 }

--- a/src/Infrastructure/Repositories/UnitOfWork.cs
+++ b/src/Infrastructure/Repositories/UnitOfWork.cs
@@ -28,6 +28,7 @@ public class UnitOfWork : IUnitOfWork, IDisposable, IAsyncDisposable
     private readonly Lazy<IScrambleRepository> _scrambleRepository;
     private readonly Lazy<IRoundStandingRepository> _roundStandingRepository;
     private readonly Lazy<ILeagueSeasonStandingRepository> _leagueSeasonStandingRepository;
+    private readonly Lazy<IPlayerRankingRepository> _playerRankingRepository;
 
     // Public properties to access the lazily loaded repositories.
     public IUserRepository UserRepository => _userRepository.Value;
@@ -41,6 +42,7 @@ public class UnitOfWork : IUnitOfWork, IDisposable, IAsyncDisposable
     public IScrambleRepository ScrambleRepository => _scrambleRepository.Value;
     public IRoundStandingRepository RoundStandingRepository => _roundStandingRepository.Value;
     public ILeagueSeasonStandingRepository LeagueSeasonStandingRepository => _leagueSeasonStandingRepository.Value;
+    public IPlayerRankingRepository PlayerRankingRepository => _playerRankingRepository.Value;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="UnitOfWork"/> class.
@@ -73,6 +75,8 @@ public class UnitOfWork : IUnitOfWork, IDisposable, IAsyncDisposable
             new Lazy<IRoundStandingRepository>(() => new RoundStandingRepository(_dbContext));
         _leagueSeasonStandingRepository =
             new  Lazy<ILeagueSeasonStandingRepository>(() => new LeagueSeasonStandingRepository(_dbContext));
+        _playerRankingRepository =
+            new Lazy<IPlayerRankingRepository>(() => new PlayerRankingRepository(_dbContext));
     }
 
     /// <inheritdoc />

--- a/src/Web/Pages/About/About.cshtml
+++ b/src/Web/Pages/About/About.cshtml
@@ -51,20 +51,51 @@
         </div>
         <div class="card-body p-0">
             <ul class="list-group list-group-flush">
-
                 <li class="list-group-item">
                     <div class="d-flex justify-content-between align-items-start">
                         <div>
-                            <strong>v0.1.0-beta</strong>
-                            <span class="badge bg-primary ms-2">Pierwsze wydanie</span>
+                            <strong>0.2.1</strong>
+                            <span class="badge bg-primary ms-2">Beta</span>
+                        </div>
+                        <small class="text-muted">08.04.2026</small>
+                    </div>
+                    <ul class="mt-2 mb-0 ps-3">
+                        <li>Dodanie odnośnika do formularza wynikowego na stronie głównej</li>
+                    </ul>
+                </li>
+                <li class="list-group-item">
+                    <div class="d-flex justify-content-between align-items-start">
+                        <div>
+                            <strong>0.2.0</strong>
+                            <span class="badge bg-primary ms-2">Beta</span>
+                        </div>
+                        <small class="text-muted">07.04.2026</small>
+                    </div>
+                    <ul class="mt-2 mb-0 ps-3">
+                        <li>Obsługa podziału lig na górną i dolną połówkę</li>
+                        <li>Wyświetlanie meczów zaplanowanych na przyszłe kolejki</li>
+                        <li>Dodany popup ze szczegółowymi informacjami w tabelach w widoku mobilnym</li>
+                        <li>Naprawiony błąd przez który dark mode wczytywał się za późno</li>
+                        <li>Naprawiony błąd przez który osoby które nic nie ułożyły przez cały sezon miały besta DNF zamiast DNS</li>
+                    </ul>
+                </li>
+                <li class="list-group-item">
+                    <div class="d-flex justify-content-between align-items-start">
+                        <div>
+                            <strong>0.1.0</strong>
+                            <span class="badge bg-primary ms-2">Beta</span>
+                            <span class="badge bg-success ms-2">Pierwsze wydanie</span>
                         </div>
                         <small class="text-muted">22.03.2026</small>
                     </div>
                     <ul class="mt-2 mb-0 ps-3">
-                        <li>Pierwsze publiczne wydanie aplikacji</li>
+                        <li>Ligi</li>
+                        <li>Kolejki</li>
+                        <li>Mecze</li>
+                        <li>Sekcje informacyjne</li>
+                        <li>Admin panel do wgrywania wyników</li>
                     </ul>
                 </li>
-
             </ul>
         </div>
     </div>

--- a/src/Web/Pages/Admin/Admin.cshtml
+++ b/src/Web/Pages/Admin/Admin.cshtml
@@ -66,6 +66,16 @@
                 </a>
             </td>
         </tr>
+        <tr>
+            <td>Rankingi</td>
+            <td>
+                <form method="post" asp-page-handler="RefreshRankings">
+                    <button type="submit" class="btn btn-sm btn-secondary">
+                        Odśwież rankingi
+                    </button>
+                </form>
+            </td>
+        </tr>
         </tbody>
     </table>
     </div>

--- a/src/Web/Pages/Admin/Admin.cshtml.cs
+++ b/src/Web/Pages/Admin/Admin.cshtml.cs
@@ -1,13 +1,26 @@
-﻿using BldLeague.Web.Attributes;
+﻿using BldLeague.Application.Commands.PlayerRankings.Refresh;
+using BldLeague.Web.Attributes;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace BldLeague.Web.Pages.Admin;
 
 [AdminOnly]
-public class Admin : PageModel
+public class Admin(IMediator mediator) : PageModel
 {
     public void OnGet()
     {
-        
+    }
+
+    public async Task<IActionResult> OnPostRefreshRankings()
+    {
+        var result = await mediator.Send(new RefreshPlayerRankingsRequest());
+        if (result.Success)
+            TempData["SuccessMessage"] = result.Message;
+        else
+            TempData["ErrorMessage"] = result.Message;
+
+        return RedirectToPage();
     }
 }

--- a/src/Web/Pages/Admin/Rounds/AddRound.cshtml
+++ b/src/Web/Pages/Admin/Rounds/AddRound.cshtml
@@ -33,6 +33,12 @@
             <span asp-validation-for="CreateRoundRequest.EndDate" class="text-danger"></span>
         </div>
 
+        <div class="mb-3">
+            <label asp-for="CreateRoundRequest.SubmissionFormUrl" class="form-label">Link do formularza (opcjonalnie)</label>
+            <input asp-for="CreateRoundRequest.SubmissionFormUrl" type="url" class="form-control" placeholder="https://forms.google.com/...">
+            <span asp-validation-for="CreateRoundRequest.SubmissionFormUrl" class="text-danger"></span>
+        </div>
+
         <button type="submit" class="btn btn-primary">Dodaj</button>
         <a asp-page="/Admin/Rounds/AllRounds" class="btn btn-outline-secondary ms-2">Anuluj</a>
     </form>

--- a/src/Web/Pages/Admin/Rounds/EditRound.cshtml
+++ b/src/Web/Pages/Admin/Rounds/EditRound.cshtml
@@ -30,6 +30,12 @@
             <span asp-validation-for="UpdateRoundRequest.EndDate" class="text-danger"></span>
         </div>
 
+        <div class="mb-3">
+            <label asp-for="UpdateRoundRequest.SubmissionFormUrl" class="form-label">Link do formularza (opcjonalnie)</label>
+            <input asp-for="UpdateRoundRequest.SubmissionFormUrl" type="url" class="form-control" placeholder="https://forms.google.com/...">
+            <span asp-validation-for="UpdateRoundRequest.SubmissionFormUrl" class="text-danger"></span>
+        </div>
+
         <hr class="my-4" />
         <h5>Scramble</h5>
 

--- a/src/Web/Pages/Admin/Rounds/EditRound.cshtml.cs
+++ b/src/Web/Pages/Admin/Rounds/EditRound.cshtml.cs
@@ -33,6 +33,7 @@ public class EditRound(IMediator mediator) : PageModel
             RoundNumber = round.RoundNumber,
             StartDate = round.StartDate,
             EndDate = round.EndDate,
+            SubmissionFormUrl = round.SubmissionFormUrl,
         };
 
         var scrambles = await mediator.Send(new GetScramblesByRoundIdRequest(round.Id));

--- a/src/Web/Pages/Index.cshtml
+++ b/src/Web/Pages/Index.cshtml
@@ -90,4 +90,20 @@
             </div>
         </a>
     </div>
+    @if (Model.ActiveRoundForm != null)
+    {
+        <div class="col-12 col-sm-6 col-md-4">
+            <a href="@Model.ActiveRoundForm.Url" class="text-decoration-none" target="_blank" rel="noopener noreferrer">
+                <div class="card h-100 border-0 shadow-sm p-3">
+                    <div class="d-flex align-items-center gap-3">
+                        <i class="bi bi-pencil-square fs-2" style="color: var(--bs-purple)"></i>
+                        <div>
+                            <div class="fw-semibold">Formularz wynikowy</div>
+                            <div class="text-muted small">Zgłoś wyniki — @Model.ActiveRoundForm.RoundName</div>
+                        </div>
+                    </div>
+                </div>
+            </a>
+        </div>
+    }
 </div>

--- a/src/Web/Pages/Index.cshtml.cs
+++ b/src/Web/Pages/Index.cshtml.cs
@@ -1,17 +1,20 @@
 using System.Security.Claims;
+using BldLeague.Application.Queries.Rounds.GetActiveFormUrl;
+using MediatR;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace BldLeague.Web.Pages;
 
-public class IndexModel : PageModel
+public class IndexModel(IMediator mediator) : PageModel
 {
     public bool IsAuthenticated { get; set; }
     public string? UserName { get; set; }
     public string? WcaId { get; set; }
     public string? Role { get; set; }
     public string? ThumbnailUrl { get; set; }
-    
-    public void OnGet()
+    public ActiveRoundFormDto? ActiveRoundForm { get; set; }
+
+    public async Task OnGet()
     {
         IsAuthenticated = User.Identity != null;
         if (User.Identity != null)
@@ -21,7 +24,7 @@ public class IndexModel : PageModel
             Role = User.FindFirst(ClaimTypes.Role)?.Value;
             ThumbnailUrl = User.FindFirst("thumbnail")?.Value;
         }
-        
-        
+
+        ActiveRoundForm = await mediator.Send(new GetActiveRoundFormUrlRequest());
     }
 }

--- a/src/Web/Pages/Rankings/Rankings.cshtml
+++ b/src/Web/Pages/Rankings/Rankings.cshtml
@@ -1,0 +1,101 @@
+@page "/Rankings/Rankings"
+@using BldLeague.Application.Queries.PlayerRankings.GetPlayerRankings
+@model BldLeague.Web.Pages.Rankings.Rankings
+
+<div class="container mt-2">
+    <h2>Rankingi</h2>
+
+    <ul class="nav nav-tabs mb-3" id="rankingTabs" role="tablist">
+        <li class="nav-item" role="presentation">
+            <button class="nav-link active" id="single-tab" data-bs-toggle="tab" data-bs-target="#single-tab-pane"
+                    type="button" role="tab" aria-controls="single-tab-pane" aria-selected="true">
+                Single
+            </button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="average-tab" data-bs-toggle="tab" data-bs-target="#average-tab-pane"
+                    type="button" role="tab" aria-controls="average-tab-pane" aria-selected="false">
+                Średnia
+            </button>
+        </li>
+    </ul>
+
+    <div class="tab-content" id="rankingTabContent">
+        <div class="tab-pane fade show active" id="single-tab-pane" role="tabpanel" aria-labelledby="single-tab" tabindex="0">
+            <div class="table-responsive">
+                <table class="table table-hover align-middle">
+                    <thead>
+                        <tr>
+                            <th scope="col" class="text-center">#</th>
+                            <th scope="col">Imię i nazwisko</th>
+                            <th scope="col">Wynik</th>
+                            <th scope="col">Kolejka</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    @if (Model.SingleRankings.Any())
+                    {
+                        foreach (var r in Model.SingleRankings)
+                        {
+                            <tr>
+                                <td class="text-center">@r.SingleRank</td>
+                                <td>@r.FullName</td>
+                                <td class="fw-bold">@r.BestSingle</td>
+                                <td>@r.RoundLabel</td>
+                            </tr>
+                        }
+                    }
+                    else
+                    {
+                        <tr>
+                            <td colspan="4" class="text-center">Brak danych.</td>
+                        </tr>
+                    }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="tab-pane fade" id="average-tab-pane" role="tabpanel" aria-labelledby="average-tab" tabindex="0">
+            <div class="table-responsive">
+                <table class="table table-hover align-middle">
+                    <thead>
+                        <tr>
+                            <th scope="col" class="text-center">#</th>
+                            <th scope="col">Imię i nazwisko</th>
+                            <th scope="col">Wynik</th>
+                            <th scope="col">Kolejka</th>
+                            <th scope="col">Ułożenia</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    @if (Model.AverageRankings.Any())
+                    {
+                        foreach (var r in Model.AverageRankings)
+                        {
+                            <tr>
+                                <td class="text-center">@r.AverageRank</td>
+                                <td>@r.FullName</td>
+                                <td class="fw-bold">@r.BestAverage</td>
+                                <td>@r.RoundLabel</td>
+                                <td class="font-monospace">
+                                    @Rankings.FormatSolveWithParens(r, 0)
+                                    @Rankings.FormatSolveWithParens(r, 1)
+                                    @Rankings.FormatSolveWithParens(r, 2)
+                                    @Rankings.FormatSolveWithParens(r, 3)
+                                    @Rankings.FormatSolveWithParens(r, 4)
+                                </td>
+                            </tr>
+                        }
+                    }
+                    else
+                    {
+                        <tr>
+                            <td colspan="5" class="text-center">Brak danych.</td>
+                        </tr>
+                    }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Web/Pages/Rankings/Rankings.cshtml.cs
+++ b/src/Web/Pages/Rankings/Rankings.cshtml.cs
@@ -1,0 +1,81 @@
+using BldLeague.Application.Queries.PlayerRankings.GetPlayerRankings;
+using BldLeague.Domain.ValueObjects;
+using MediatR;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace BldLeague.Web.Pages.Rankings;
+
+public class Rankings(IMediator mediator) : PageModel
+{
+    public IReadOnlyCollection<SingleRankingDto> SingleRankings { get; set; } = new List<SingleRankingDto>();
+    public IReadOnlyCollection<AverageRankingDto> AverageRankings { get; set; } = new List<AverageRankingDto>();
+
+    public async Task OnGet()
+    {
+        var response = await mediator.Send(new GetPlayerRankingsRequest());
+        SingleRankings = response.SingleRankings;
+        AverageRankings = response.AverageRankings;
+    }
+
+    public static string FormatSolveWithParens(AverageRankingDto dto, int solveIndex)
+    {
+        var solves = new[] { dto.Solve1, dto.Solve2, dto.Solve3, dto.Solve4, dto.Solve5 };
+        var solve = solves[solveIndex];
+
+        // Determine best (min valid) and worst (first DNF/DNS if any, else max valid)
+        var validSolves = solves.Where(s => s.IsValid).ToList();
+        bool isBest = false;
+        bool isWorst = false;
+
+        if (validSolves.Count > 0)
+        {
+            int minCs = validSolves.Min(s => s.Centiseconds);
+            // best is lowest valid
+            if (solve.IsValid && solve.Centiseconds == minCs)
+            {
+                // mark as best only for the first occurrence of this value
+                bool foundEarlier = false;
+                for (int i = 0; i < solveIndex; i++)
+                {
+                    if (solves[i].IsValid && solves[i].Centiseconds == minCs)
+                    {
+                        foundEarlier = true;
+                        break;
+                    }
+                }
+                if (!foundEarlier) isBest = true;
+            }
+        }
+
+        // worst: first DNF/DNS if any, else first max valid
+        bool hasDnfOrDns = solves.Any(s => !s.IsValid);
+        if (hasDnfOrDns)
+        {
+            // worst = first DNF or DNS
+            for (int i = 0; i < solves.Length; i++)
+            {
+                if (!solves[i].IsValid)
+                {
+                    if (i == solveIndex) isWorst = true;
+                    break;
+                }
+            }
+        }
+        else if (validSolves.Count > 0)
+        {
+            int maxCs = validSolves.Max(s => s.Centiseconds);
+            for (int i = 0; i < solves.Length; i++)
+            {
+                if (solves[i].IsValid && solves[i].Centiseconds == maxCs)
+                {
+                    if (i == solveIndex) isWorst = true;
+                    break;
+                }
+            }
+        }
+
+        string display = solve.ToString();
+        if (isBest || isWorst) return $"({display})";
+        return display;
+    }
+}

--- a/src/Web/Pages/Shared/_Layout.cshtml
+++ b/src/Web/Pages/Shared/_Layout.cshtml
@@ -61,6 +61,9 @@
                             <li><a class="dropdown-item" asp-area="" asp-page="/Matches/MatchList">Mecze</a></li>
                         </ul>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link" asp-area="" asp-page="/Rankings/Rankings">Rankingi</a>
+                    </li>
                     <li class="nav-item dropdown">
                         <a class="nav-link dropdown-toggle" href="#" role="button"
                            data-bs-toggle="dropdown" aria-expanded="false">


### PR DESCRIPTION
Closes #48

## Summary

- Adds a public `/Rankings/Rankings` page with Bootstrap tabs for best single and best Ao5 average rankings, ranked with WCA tie logic
- Introduces a `PlayerRanking` entity (one row per user) storing pre-computed best single, best average, and the 5 individual solves from the PB average round
- Rankings are refreshed automatically after every round standings refresh (match create/edit/delete), and via a new "Odśwież rankingi" button on the admin panel
- "Rankingi" nav link added to the top navbar

🤖 Generated with [Claude Code](https://claude.ai/claude-code)