### PR TITLE
Fix EF Core KeyNotFoundException in best-per-user ranking queries

### DIFF
--- a/src/Infrastructure/Repositories/RoundStandingRepository.cs
+++ b/src/Infrastructure/Repositories/RoundStandingRepository.cs
@@ -31,23 +31,29 @@ public class RoundStandingRepository(AppDbContext context)
 
     public async Task<IReadOnlyCollection<BestSinglePerUserDto>> GetBestSinglePerUserAsync()
     {
-        return await DbSet
+        var rows = await DbSet
             .Where(rs => rs.Best >= (SolveResult)0)
             .GroupBy(rs => rs.UserId)
             .Select(g => g.OrderBy(rs => rs.Best).First())
-            .Select(rs => new BestSinglePerUserDto(rs.UserId, rs.Best, rs.RoundId))
             .ToListAsync();
+
+        return rows
+            .Select(rs => new BestSinglePerUserDto(rs.UserId, rs.Best, rs.RoundId))
+            .ToList();
     }
 
     public async Task<IReadOnlyCollection<BestAveragePerUserDto>> GetBestAveragePerUserAsync()
     {
-        return await DbSet
+        var rows = await DbSet
             .Where(rs => rs.Average >= (SolveResult)0)
             .GroupBy(rs => rs.UserId)
             .Select(g => g.OrderBy(rs => rs.Average).First())
+            .ToListAsync();
+
+        return rows
             .Select(rs => new BestAveragePerUserDto(
                 rs.UserId, rs.Average, rs.RoundId,
                 rs.Solve1, rs.Solve2, rs.Solve3, rs.Solve4, rs.Solve5))
-            .ToListAsync();
+            .ToList();
     }
 }


### PR DESCRIPTION
Closes #51

## Summary

EF Core cannot chain a second `.Select()` after `GroupBy(...).Select(g => g.OrderBy(...).First())` — it throws `KeyNotFoundException: The given key 'EmptyProjectionMember'` in the query translator.

Fix: materialise the entity rows with `ToListAsync` first, then project to the DTO in-memory. The GroupBy/OrderBy/First still runs in the database, so only one row per user is transferred.