### PR TITLE
Add promotion/relegation counts to LeagueSeason

### DIFF
--- a/src/Application/Commands/LeagueSeasons/Create/CreateLeagueSeasonRequest.cs
+++ b/src/Application/Commands/LeagueSeasons/Create/CreateLeagueSeasonRequest.cs
@@ -10,4 +10,6 @@ public class CreateLeagueSeasonRequest : IRequest<CommandResult>
 {
     public Guid SeasonId { get; set; }
     public Guid LeagueId { get; set; }
+    public int PromotionCount { get; set; }
+    public int RelegationCount { get; set; }
 }

--- a/src/Application/Commands/LeagueSeasons/Create/CreateLeagueSeasonRequestHandler.cs
+++ b/src/Application/Commands/LeagueSeasons/Create/CreateLeagueSeasonRequestHandler.cs
@@ -26,7 +26,7 @@ public class CreateLeagueSeasonRequestHandler(IUnitOfWork unitOfWork)
         if (exists)
             return CommandResult.FailGeneral("Ten liga-sezon już istnieje.");
 
-        var leagueSeason = LeagueSeason.Create(league, season);
+        var leagueSeason = LeagueSeason.Create(league, season, request.PromotionCount, request.RelegationCount);
         await unitOfWork.LeagueSeasonRepository.AddAsync(leagueSeason);
         await unitOfWork.SaveAsync();
         return CommandResult.Ok($"Utworzono liga-sezon: {league.LeagueName} — {season.SeasonName}.");

--- a/src/Application/Commands/LeagueSeasons/Update/UpdateLeagueSeasonSettingsRequest.cs
+++ b/src/Application/Commands/LeagueSeasons/Update/UpdateLeagueSeasonSettingsRequest.cs
@@ -1,0 +1,11 @@
+using BldLeague.Application.Common;
+using MediatR;
+
+namespace BldLeague.Application.Commands.LeagueSeasons.Update;
+
+public class UpdateLeagueSeasonSettingsRequest : IRequest<CommandResult>
+{
+    public Guid LeagueSeasonId { get; set; }
+    public int PromotionCount { get; set; }
+    public int RelegationCount { get; set; }
+}

--- a/src/Application/Commands/LeagueSeasons/Update/UpdateLeagueSeasonSettingsRequestHandler.cs
+++ b/src/Application/Commands/LeagueSeasons/Update/UpdateLeagueSeasonSettingsRequestHandler.cs
@@ -1,0 +1,23 @@
+using BldLeague.Application.Abstractions.Repositories;
+using BldLeague.Application.Common;
+using MediatR;
+
+namespace BldLeague.Application.Commands.LeagueSeasons.Update;
+
+public class UpdateLeagueSeasonSettingsRequestHandler(IUnitOfWork unitOfWork)
+    : IRequestHandler<UpdateLeagueSeasonSettingsRequest, CommandResult>
+{
+    public async Task<CommandResult> Handle(UpdateLeagueSeasonSettingsRequest request, CancellationToken cancellationToken)
+    {
+        var leagueSeason = await unitOfWork.LeagueSeasonRepository.GetByIdAsync(request.LeagueSeasonId);
+        if (leagueSeason == null)
+            return CommandResult.FailGeneral($"Nie znaleziono liga-sezonu z ID: {request.LeagueSeasonId}.");
+
+        leagueSeason.PromotionCount = request.PromotionCount;
+        leagueSeason.RelegationCount = request.RelegationCount;
+        unitOfWork.LeagueSeasonRepository.Update(leagueSeason);
+        await unitOfWork.SaveAsync();
+
+        return CommandResult.Ok("Zaktualizowano ustawienia liga-sezonu.");
+    }
+}

--- a/src/Application/Queries/LeagueSeasons/GetAll/LeagueSeasonDto.cs
+++ b/src/Application/Queries/LeagueSeasons/GetAll/LeagueSeasonDto.cs
@@ -13,4 +13,6 @@ public class LeagueSeasonDto
     public string SeasonName { get; set; } = string.Empty;
     public int UserCount { get; set; }
     public Guid SeasonId { get; set; }
+    public int PromotionCount { get; set; }
+    public int RelegationCount { get; set; }
 }

--- a/src/Application/Queries/LeagueSeasons/GetDetail/LeagueSeasonDetailDto.cs
+++ b/src/Application/Queries/LeagueSeasons/GetDetail/LeagueSeasonDetailDto.cs
@@ -6,4 +6,6 @@ namespace BldLeague.Application.Queries.LeagueSeasons.GetDetail;
 public class LeagueSeasonDetailDto
 {
     public required List<LeagueSeasonStandingDto> Standings { get; set; }
+    public int PromotionCount { get; set; }
+    public int RelegationCount { get; set; }
 }

--- a/src/Domain/Entities/LeagueSeason.cs
+++ b/src/Domain/Entities/LeagueSeason.cs
@@ -46,18 +46,32 @@ public class LeagueSeason : IIdentifiable
     public ICollection<Match> Matches { get; set; } = new List<Match>();
     
     /// <summary>
+    /// Number of top-placed players to display as promoted. Zero means no promotion icons are shown.
+    /// </summary>
+    public int PromotionCount { get; set; }
+
+    /// <summary>
+    /// Number of bottom-placed players to display as relegated. Zero means no relegation icons are shown.
+    /// </summary>
+    public int RelegationCount { get; set; }
+
+    /// <summary>
     /// Factory method for LeagueSeason.
     /// </summary>
     /// <param name="league">Associated league.</param>
     /// <param name="season">Associated Season.</param>
+    /// <param name="promotionCount">Number of promoted places (default 0).</param>
+    /// <param name="relegationCount">Number of relegated places (default 0).</param>
     /// <returns></returns>
-    public static LeagueSeason Create(League league, Season season)
+    public static LeagueSeason Create(League league, Season season, int promotionCount = 0, int relegationCount = 0)
         => new LeagueSeason
         {
             Id = Guid.CreateVersion7(),
             League = league,
             LeagueId = league.Id,
             Season = season,
-            SeasonId = season.Id
+            SeasonId = season.Id,
+            PromotionCount = promotionCount,
+            RelegationCount = relegationCount
         };
 }

--- a/src/Infrastructure/Configuration/LeagueSeasonConfiguration.cs
+++ b/src/Infrastructure/Configuration/LeagueSeasonConfiguration.cs
@@ -22,6 +22,9 @@ public class LeagueSeasonConfiguration : IEntityTypeConfiguration<LeagueSeason>
             .HasForeignKey(ls => ls.SeasonId)
             .IsRequired();
         
+        b.Property(ls => ls.PromotionCount).HasDefaultValue(0);
+        b.Property(ls => ls.RelegationCount).HasDefaultValue(0);
+
         // Enforce unique League+Season combination
         b.HasIndex(ls => new { ls.LeagueId, ls.SeasonId })
             .IsUnique();

--- a/src/Infrastructure/Migrations/20260412154029_AddLeagueSeasonPromotionRelegation.Designer.cs
+++ b/src/Infrastructure/Migrations/20260412154029_AddLeagueSeasonPromotionRelegation.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BldLeague.Infrastructure.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BldLeague.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260412154029_AddLeagueSeasonPromotionRelegation")]
+    partial class AddLeagueSeasonPromotionRelegation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Migrations/20260412154029_AddLeagueSeasonPromotionRelegation.cs
+++ b/src/Infrastructure/Migrations/20260412154029_AddLeagueSeasonPromotionRelegation.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BldLeague.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLeagueSeasonPromotionRelegation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "promotion_count",
+                table: "league_seasons",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "relegation_count",
+                table: "league_seasons",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "promotion_count",
+                table: "league_seasons");
+
+            migrationBuilder.DropColumn(
+                name: "relegation_count",
+                table: "league_seasons");
+        }
+    }
+}

--- a/src/Infrastructure/Repositories/LeagueSeasonRepository.cs
+++ b/src/Infrastructure/Repositories/LeagueSeasonRepository.cs
@@ -56,7 +56,9 @@ public class LeagueSeasonRepository(AppDbContext context) :
                 SeasonNumber = ls.Season.SeasonNumber,
                 SeasonName = ls.Season.SeasonName,
                 SeasonId = ls.SeasonId,
-                UserCount = ls.LeagueSeasonUsers.Count
+                UserCount = ls.LeagueSeasonUsers.Count,
+                PromotionCount = ls.PromotionCount,
+                RelegationCount = ls.RelegationCount
             })
             .FirstOrDefaultAsync();
 
@@ -65,6 +67,8 @@ public class LeagueSeasonRepository(AppDbContext context) :
             .Where(ls => ls.SeasonId == seasonId && ls.LeagueId == leagueId)
             .Select(ls => new LeagueSeasonDetailDto
             {
+                PromotionCount = ls.PromotionCount,
+                RelegationCount = ls.RelegationCount,
                 Standings = ls.LeagueSeasonStandings
                     .OrderBy(lss => lss.Place)
                     .ThenBy(lss => lss.User.FullName)

--- a/src/Web/Pages/Admin/LeagueSeasons/AddLeagueSeason.cshtml
+++ b/src/Web/Pages/Admin/LeagueSeasons/AddLeagueSeason.cshtml
@@ -22,6 +22,16 @@
             </select>
         </div>
 
+        <div class="mb-3">
+            <label asp-for="CreateLeagueSeasonRequest.PromotionCount" class="form-label">Liczba awansów</label>
+            <input asp-for="CreateLeagueSeasonRequest.PromotionCount" type="number" min="0" class="form-control" />
+        </div>
+
+        <div class="mb-3">
+            <label asp-for="CreateLeagueSeasonRequest.RelegationCount" class="form-label">Liczba spadków</label>
+            <input asp-for="CreateLeagueSeasonRequest.RelegationCount" type="number" min="0" class="form-control" />
+        </div>
+
         <button type="submit" class="btn btn-primary">Dodaj</button>
         <a asp-page="/Admin/LeagueSeasons/AllLeagueSeasons" class="btn btn-outline-secondary ms-2">Anuluj</a>
     </form>

--- a/src/Web/Pages/Admin/LeagueSeasons/EditLeagueSeason.cshtml
+++ b/src/Web/Pages/Admin/LeagueSeasons/EditLeagueSeason.cshtml
@@ -48,6 +48,20 @@
         </div>
     }
 
+    <form method="post" asp-page-handler="SaveSettings" class="mb-4" style="max-width: 400px;">
+        <h3>Ustawienia awansu / spadku</h3>
+        <input type="hidden" asp-for="LeagueSeasonSettings.LeagueSeasonId" />
+        <div class="mb-3">
+            <label asp-for="LeagueSeasonSettings.PromotionCount" class="form-label">Liczba awansów</label>
+            <input asp-for="LeagueSeasonSettings.PromotionCount" type="number" min="0" class="form-control" />
+        </div>
+        <div class="mb-3">
+            <label asp-for="LeagueSeasonSettings.RelegationCount" class="form-label">Liczba spadków</label>
+            <input asp-for="LeagueSeasonSettings.RelegationCount" type="number" min="0" class="form-control" />
+        </div>
+        <button type="submit" class="btn btn-primary">Zapisz ustawienia</button>
+    </form>
+
     <form id="saveGroupsForm" method="post" asp-page-handler="SaveGroups"></form>
 
     <div class="table-responsive">

--- a/src/Web/Pages/Admin/LeagueSeasons/EditLeagueSeason.cshtml.cs
+++ b/src/Web/Pages/Admin/LeagueSeasons/EditLeagueSeason.cshtml.cs
@@ -2,6 +2,7 @@ using BldLeague.Application.Commands.LeagueSeasonUsers.Create;
 using BldLeague.Application.Commands.LeagueSeasonUsers.Delete;
 using BldLeague.Application.Commands.LeagueSeasonUsers.Import;
 using BldLeague.Application.Commands.LeagueSeasonUsers.SetGroup;
+using BldLeague.Application.Commands.LeagueSeasons.Update;
 using BldLeague.Application.Common;
 using BldLeague.Application.Queries.LeagueSeasons.GetAll;
 using BldLeague.Application.Queries.LeagueSeasons.GetById;
@@ -32,6 +33,7 @@ public class EditLeagueSeason(IMediator mediator) : PageModel
     [BindProperty] public List<Guid> SelectedUserIds { get; set; } = [];
     [BindProperty] public Guid? RemoveUserId { get; set; }
     [BindProperty] public List<UserGroupInput> UserGroups { get; set; } = [];
+    [BindProperty] public UpdateLeagueSeasonSettingsRequest LeagueSeasonSettings { get; set; } = new();
 
     public class UserGroupInput
     {
@@ -47,6 +49,13 @@ public class EditLeagueSeason(IMediator mediator) : PageModel
             TempData["ErrorMessage"] = $"Nie znaleziono sezonu w lidze z id: {Id}.";
             return RedirectToPage("/Admin/LeagueSeasons/AllLeagueSeasons");
         }
+
+        LeagueSeasonSettings = new UpdateLeagueSeasonSettingsRequest
+        {
+            LeagueSeasonId = Id,
+            PromotionCount = LeagueSeason.PromotionCount,
+            RelegationCount = LeagueSeason.RelegationCount
+        };
 
         AssignedUsers = await mediator.Send(new GetUsersByLeagueSeasonIdRequest(Id));
         UnassignedUsers = await mediator.Send(new GetUnassignedUsersBySeasonIdRequest(LeagueSeason.SeasonId));
@@ -110,6 +119,20 @@ public class EditLeagueSeason(IMediator mediator) : PageModel
         };
 
         var result = await mediator.Send(request);
+
+        if (result.Success)
+            TempData["SuccessMessage"] = result.Message;
+        else
+            TempData["ErrorMessage"] = result.Message;
+
+        return RedirectToPage();
+    }
+
+    public async Task<IActionResult> OnPostSaveSettingsAsync()
+    {
+        LeagueSeasonSettings.LeagueSeasonId = Id;
+
+        var result = await mediator.Send(LeagueSeasonSettings);
 
         if (result.Success)
             TempData["SuccessMessage"] = result.Message;

--- a/src/Web/Pages/Leagues/ViewLeague.cshtml
+++ b/src/Web/Pages/Leagues/ViewLeague.cshtml
@@ -72,7 +72,17 @@
                         data-rp="@standing.SmallPointsBalance"
                         data-best="@standing.Best">
                         <td class="text-center">@standing.Place</td>
-                        <td>@standing.UserFullName</td>
+                        <td>
+                            @standing.UserFullName
+                            @if (Model.LeagueSeason.PromotionCount > 0 && standing.Place <= Model.LeagueSeason.PromotionCount)
+                            {
+                                <i class="bi bi-arrow-up-circle-fill text-success ms-1"></i>
+                            }
+                            @if (Model.LeagueSeason.RelegationCount > 0 && standing.Place > Model.LeagueSeason.Standings.Count - Model.LeagueSeason.RelegationCount)
+                            {
+                                <i class="bi bi-arrow-down-circle-fill text-danger ms-1"></i>
+                            }
+                        </td>
                         <td class="text-center d-none d-md-table-cell">@standing.MatchesPlayed</td>
                         <td class="text-center d-none d-md-table-cell">@standing.MatchesWon</td>
                         <td class="text-center d-none d-md-table-cell">@standing.MatchesTied</td>

--- a/src/Web/ViewModels/LeagueSeasonDetailViewModel.cs
+++ b/src/Web/ViewModels/LeagueSeasonDetailViewModel.cs
@@ -5,12 +5,16 @@ namespace BldLeague.Web.ViewModels;
 public class LeagueSeasonDetailViewModel
 {
     public required List<LeagueSeasonStandingViewModel> Standings { get; set; }
+    public int PromotionCount { get; set; }
+    public int RelegationCount { get; set; }
 
     public static LeagueSeasonDetailViewModel FromDto(LeagueSeasonDetailDto dto)
     {
         return new LeagueSeasonDetailViewModel
         {
             Standings = dto.Standings.Select(LeagueSeasonStandingViewModel.FromDto).ToList(),
+            PromotionCount = dto.PromotionCount,
+            RelegationCount = dto.RelegationCount,
         };
     }
 }


### PR DESCRIPTION
## Summary

- Added `PromotionCount` and `RelegationCount` fields to the `LeagueSeason` entity, stored as DB columns with default `0`
- Admin can set both counts when creating a LeagueSeason, and edit them later via a new settings form on the EditLeagueSeason page
- Public standings page (`ViewLeague`) now renders a green up-arrow icon for promoted places and a red down-arrow icon for relegated places

Closes #56