### PR TITLE
Fix match status: round's last day incorrectly treated as Finished

### DIFF
--- a/src/Web/ViewModels/MatchDetailsViewModel.cs
+++ b/src/Web/ViewModels/MatchDetailsViewModel.cs
@@ -32,9 +32,9 @@ public class MatchDetailsViewModel : MatchSummaryViewModel
     public static MatchDetailsViewModel FromDto(MatchDetailsDto dto)
     {
         var now = DateTime.UtcNow;
-        var status = dto.RoundEndDate < now
+        var status = now.Date > dto.RoundEndDate.Date
             ? MatchStatus.Finished
-            : dto.RoundStartDate <= now
+            : now.Date >= dto.RoundStartDate.Date
                 ? MatchStatus.InProgress
                 : MatchStatus.Upcoming;
 

--- a/src/Web/ViewModels/MatchSummaryViewModel.cs
+++ b/src/Web/ViewModels/MatchSummaryViewModel.cs
@@ -16,9 +16,9 @@ public class MatchSummaryViewModel
     public static MatchSummaryViewModel FromDto(MatchSummaryDto dto)
     {
         var now = DateTime.UtcNow;
-        var status = dto.RoundEndDate < now
+        var status = now.Date > dto.RoundEndDate.Date
             ? MatchStatus.Finished
-            : dto.RoundStartDate <= now
+            : now.Date >= dto.RoundStartDate.Date
                 ? MatchStatus.InProgress
                 : MatchStatus.Upcoming;
 


### PR DESCRIPTION
## Summary

- Switch `MatchSummaryViewModel` and `MatchDetailsViewModel` from timestamp comparison (`EndDate < now`) to date-only comparison (`now.Date > EndDate.Date`), making the round's last day inclusive (InProgress, not Finished)
- No database migration needed — stored midnight-UTC values work correctly with `.Date` comparison
- Consistent with `RoundRepository.GetActiveRoundFormUrlAsync` which already uses equivalent day-boundary logic

Closes #55