### PR TITLE
chore: QoL — avatar display, tooltips, cursor, navbar links, changelog (#67)

### DIFF
--- a/src/Web/Pages/About/About.cshtml
+++ b/src/Web/Pages/About/About.cshtml
@@ -33,8 +33,8 @@
             <p class="mb-1">Planowane funkcje:</p>
             <ul class="mb-3">
                 <li>Logowanie przez konto WCA i samodzielne wgrywanie wyników</li>
-                <li>Profile użytkowników z historią ułożeń, najlepszymi czasami itp.</li>
-                <li>Rankingi</li>
+                <li><s>Profile użytkowników z historią ułożeń, najlepszymi czasami itp.</s> <span class="badge bg-success">Dodane</span></li>
+                <li><s>Rankingi</s> <span class="badge bg-success">Dodane</span></li>
                 <li>Statystyki</li>
             </ul>
             <p class="mb-2">Autorem aplikacji jest <strong>Kamil Przybylski</strong>.</p>
@@ -51,6 +51,20 @@
         </div>
         <div class="card-body p-0">
             <ul class="list-group list-group-flush">
+                <li class="list-group-item">
+                    <div class="d-flex justify-content-between align-items-start">
+                        <div>
+                            <strong>0.3.0</strong>
+                            <span class="badge bg-primary ms-2">Beta</span>
+                        </div>
+                        <small class="text-muted">12.04.2026</small>
+                    </div>
+                    <ul class="mt-2 mb-0 ps-3">
+                        <li>Dodanie profili zawodników</li>
+                        <li>Dodanie rankingów strony</li>
+                        <li>Wyświetlanie awansów, spadków i baraży w tabeli ligi</li>
+                    </ul>
+                </li>
                 <li class="list-group-item">
                     <div class="d-flex justify-content-between align-items-start">
                         <div>

--- a/src/Web/Pages/Account/RefreshAvatar.cshtml
+++ b/src/Web/Pages/Account/RefreshAvatar.cshtml
@@ -1,0 +1,6 @@
+@page
+@model BldLeague.Web.Pages.Account.RefreshAvatar
+
+@{
+    Layout = null;
+}

--- a/src/Web/Pages/Account/RefreshAvatar.cshtml.cs
+++ b/src/Web/Pages/Account/RefreshAvatar.cshtml.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.Security.Claims;
+
+namespace BldLeague.Web.Pages.Account;
+
+[Authorize]
+public class RefreshAvatar : PageModel
+{
+    public async Task<IActionResult> OnGetAsync()
+    {
+        var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+        return Challenge(new AuthenticationProperties
+        {
+            RedirectUri = userId != null ? $"/Users/{userId}" : "/"
+        }, "WCA");
+    }
+}

--- a/src/Web/Pages/Shared/_Layout.cshtml
+++ b/src/Web/Pages/Shared/_Layout.cshtml
@@ -108,6 +108,22 @@
                             </a>
 
                             <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
+                                @{
+                                    var currentUserId = User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+                                }
+                                <li>
+                                    <a class="dropdown-item" asp-page="/Users/UserProfile" asp-route-id="@currentUserId">
+                                        <i class="bi bi-person" style="margin-right: 0.5rem;"></i>
+                                        Mój profil
+                                    </a>
+                                </li>
+                                <li>
+                                    <a class="dropdown-item" href="/Account/RefreshAvatar">
+                                        <i class="bi bi-arrow-clockwise" style="margin-right: 0.5rem;"></i>
+                                        Odśwież awatar
+                                    </a>
+                                </li>
+                                <li><hr class="dropdown-divider" /></li>
                                 <li>
                                     <form method="post" asp-page="/Account/Logout" class="m-0">
                                         <button type="submit" class="dropdown-item text-danger px-3">

--- a/src/Web/Pages/Users/UserProfile.cshtml
+++ b/src/Web/Pages/Users/UserProfile.cshtml
@@ -9,11 +9,11 @@
     <div class="text-center mb-4">
         @if (Model.Profile!.AvatarUrl != null)
         {
-            <img src="@Model.Profile.AvatarUrl" alt="Avatar" class="rounded-circle mb-2" style="width:96px;height:96px;object-fit:cover;" />
+            <img src="@Model.Profile.AvatarUrl" alt="Avatar" class="mb-2" style="max-width:200px;height:auto;" />
         }
         else if (Model.Profile.AvatarThumbnailUrl != null)
         {
-            <img src="@Model.Profile.AvatarThumbnailUrl" alt="Avatar" class="rounded-circle mb-2" style="width:96px;height:96px;object-fit:cover;" />
+            <img src="@Model.Profile.AvatarThumbnailUrl" alt="Avatar" class="mb-2" style="max-width:200px;height:auto;" />
         }
         else
         {
@@ -35,10 +35,10 @@
             <thead>
             <tr>
                 <th>Konkurencja</th>
-                <th title="Rekord ligi">LR (single)</th>
+                <th data-bs-toggle="tooltip" title="Rekord ligi">LR (single)</th>
                 <th>Best</th>
                 <th>Średnia</th>
-                <th title="Rekord ligi">LR (avg)</th>
+                <th data-bs-toggle="tooltip" title="Rekord ligi">LR (avg)</th>
             </tr>
             </thead>
             <tbody>
@@ -468,6 +468,9 @@
     }
     <script>
         document.addEventListener("DOMContentLoaded", function () {
+            [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+                .forEach(function (el) { new bootstrap.Tooltip(el); });
+
             const modal = bootstrap.Modal.getOrCreateInstance(document.getElementById('roundDetailModal'));
             const modalBody = document.getElementById('roundDetailBody');
 

--- a/src/Web/wwwroot/css/site.css
+++ b/src/Web/wwwroot/css/site.css
@@ -88,7 +88,9 @@ body {
 }
 
 @media (max-width: 767.98px) {
-    tr.js-detail-row { cursor: pointer; }
+    tr.js-detail-row,
+    tr.js-round-row,
+    tr.js-avg-row { cursor: pointer; }
 }
 
 /* Invert event icons in dark mode so they appear white */


### PR DESCRIPTION
## Summary

- Fixes avatar display on user profile (responsive size, removed forced circle crop)
- Adds Bootstrap tooltips to L/R column headers on the profile page
- Extends pointer cursor to round/average stat rows on mobile
- Adds "Mój profil" and "Odśwież awatar" links to the authenticated user's navbar dropdown
- Adds 0.3.0 changelog entry and marks completed planned features on the About page

Closes #67