### PR TITLE
chore: pre-0.4.0 QOL improvements and live-submission fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,7 @@ Avoid JavaScript by default. Prefer server-side form submissions and page reload
 | League queries + DTOs | `src/Application/Queries/Leagues/` |
 | Season queries + DTOs | `src/Application/Queries/Seasons/` |
 | LeagueSeason queries + DTOs | `src/Application/Queries/LeagueSeasons/` |
+| User league for a given season (`GetUserLeagueIdForSeasonRequest`) | `src/Application/Queries/LeagueSeasons/GetUserLeagueIdForSeason/` |
 | Round queries + DTOs (incl. `ScrambleDto`, `RoundSummaryDto`) | `src/Application/Queries/Rounds/` |
 | Match queries + DTOs (incl. `SolveDto`, `MatchDetailsDto`, `MatchExportRowDto`) | `src/Application/Queries/Matches/` |
 | Active submission query + `ActiveSubmissionDto` | `src/Application/Queries/Matches/GetActiveSubmission/` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,7 @@ Avoid JavaScript by default. Prefer server-side form submissions and page reload
 | `CsvHelper` (CSV builder, UTF-8 BOM) | `src/Web/Helpers/CsvHelper.cs` |
 | `CsvParser` (CSV `IFormFile` parser) | `src/Web/Helpers/CsvParser.cs` |
 | `SolveFormatHelper` (Ao5 best/worst parentheses formatting) | `src/Web/Helpers/SolveFormatHelper.cs` |
+| `PageModelExtensions` (signed-in user league resolution) | `src/Web/Helpers/PageModelExtensions.cs` |
 | `EnvironmentBadgeOptions` (optional navbar env label) | `src/Web/Options/EnvironmentBadgeOptions.cs` |
 | `MatchStatus` enum (Upcoming/InProgress/Finished) | `src/Web/ViewModels/MatchStatus.cs` |
 | ViewModels | `src/Web/ViewModels/` |

--- a/src/Application/Abstractions/Repositories/ILeagueSeasonUserRepository.cs
+++ b/src/Application/Abstractions/Repositories/ILeagueSeasonUserRepository.cs
@@ -7,4 +7,5 @@ public interface ILeagueSeasonUserRepository : IReadWriteRepository<LeagueSeason
 {
     Task<IReadOnlyCollection<LeagueSeasonUserDto>> GetUsersByLeagueSeasonIdAsync(Guid leagueSeasonId);
     Task<LeagueSeasonUser?> GetAsync(Guid leagueSeasonId, Guid userId);
+    Task<Guid?> GetUserLeagueIdForSeasonAsync(Guid userId, Guid seasonId);
 }

--- a/src/Application/Abstractions/Repositories/ISolveRepository.cs
+++ b/src/Application/Abstractions/Repositories/ISolveRepository.cs
@@ -5,7 +5,7 @@ namespace BldLeague.Application.Abstractions.Repositories;
 
 public interface ISolveRepository : IReadWriteRepository<Solve>
 {
-    public Task<IReadOnlyCollection<(Guid, SolveResult)>> GetBestSolvesForLeagueSeason(Guid leagueSeasonId);
+    public Task<IReadOnlyCollection<(Guid, SolveResult)>> GetBestSolvesForLeagueSeason(Guid leagueSeasonId, DateTime cutoff);
     Task<IReadOnlyCollection<SolveResult>> GetFinishedSolvesByUserIdAsync(Guid userId, DateTime localToday);
     Task<IReadOnlyCollection<Solve>> GetByMatchIdAsync(Guid matchId);
 }

--- a/src/Application/Commands/LeagueSeasonStandings/Refresh/RefreshLeagueSeasonStandingsRequestHandler.cs
+++ b/src/Application/Commands/LeagueSeasonStandings/Refresh/RefreshLeagueSeasonStandingsRequestHandler.cs
@@ -106,7 +106,7 @@ public class RefreshLeagueSeasonStandingsRequestHandler(IUnitOfWork unitOfWork, 
 
         // 3. Calculate best solve
         var bestSolves = await unitOfWork.SolveRepository.GetBestSolvesForLeagueSeason(
-            request.LeagueSeasonId);
+            request.LeagueSeasonId, roundClock.LocalToday());
 
         foreach (var bestSolve in bestSolves)
         {

--- a/src/Application/Queries/LeagueSeasons/GetUserLeagueIdForSeason/GetUserLeagueIdForSeasonRequest.cs
+++ b/src/Application/Queries/LeagueSeasons/GetUserLeagueIdForSeason/GetUserLeagueIdForSeasonRequest.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace BldLeague.Application.Queries.LeagueSeasons.GetUserLeagueIdForSeason;
+
+public record GetUserLeagueIdForSeasonRequest(Guid UserId, Guid SeasonId) : IRequest<Guid?>;

--- a/src/Application/Queries/LeagueSeasons/GetUserLeagueIdForSeason/GetUserLeagueIdForSeasonRequestHandler.cs
+++ b/src/Application/Queries/LeagueSeasons/GetUserLeagueIdForSeason/GetUserLeagueIdForSeasonRequestHandler.cs
@@ -1,0 +1,11 @@
+using BldLeague.Application.Abstractions.Repositories;
+using MediatR;
+
+namespace BldLeague.Application.Queries.LeagueSeasons.GetUserLeagueIdForSeason;
+
+public class GetUserLeagueIdForSeasonRequestHandler(IUnitOfWork unitOfWork)
+    : IRequestHandler<GetUserLeagueIdForSeasonRequest, Guid?>
+{
+    public Task<Guid?> Handle(GetUserLeagueIdForSeasonRequest request, CancellationToken cancellationToken)
+        => unitOfWork.LeagueSeasonUserRepository.GetUserLeagueIdForSeasonAsync(request.UserId, request.SeasonId);
+}

--- a/src/Application/Queries/Rounds/GetAllBySeasonId/RoundSummaryDto.cs
+++ b/src/Application/Queries/Rounds/GetAllBySeasonId/RoundSummaryDto.cs
@@ -17,25 +17,11 @@ public static class RoundSummaryDtoExtensions
     /// Returns the default round to display when the user hasn't picked one.
     /// Assumes <paramref name="rounds"/> is ordered by RoundNumber ascending (as returned by the repository).
     ///
-    /// Current behaviour: show the round immediately before the active one, so the page
-    /// opens on the most recently completed round that already has results.
-    /// If the active round is the first one (no previous), or if no round is active,
-    /// falls back to the round with the highest RoundNumber.
-    ///
-    /// When live results are available, swap to the commented-out line below to open
-    /// directly on the in-progress round instead.
+    /// Returns the currently active round if one exists; otherwise falls back to the round with the highest RoundNumber.
     /// </summary>
     public static RoundSummaryDto GetDefaultRound(this IReadOnlyCollection<RoundSummaryDto> rounds, DateTime today)
     {
-        // Future: open directly on the active (in-progress) round.
-        // var active = rounds.FirstOrDefault(r => r.StartDate <= today && today <= r.EndDate);
-        // return active ?? rounds.Last();
-
-        var list = rounds.ToList(); // already sorted ascending by RoundNumber
-        var activeIndex = list.FindIndex(r => r.StartDate <= today && today <= r.EndDate);
-
-        // One round before the active one; fall back to the last round if there is no
-        // active round or if the active round is the very first one.
-        return activeIndex > 0 ? list[activeIndex - 1] : list[^1];
+        var active = rounds.FirstOrDefault(r => r.StartDate <= today && today <= r.EndDate);
+        return active ?? rounds.Last();
     }
 }

--- a/src/Application/Queries/Rounds/GetAllBySeasonId/RoundSummaryDto.cs
+++ b/src/Application/Queries/Rounds/GetAllBySeasonId/RoundSummaryDto.cs
@@ -1,3 +1,5 @@
+using BldLeague.Application.Common;
+
 namespace BldLeague.Application.Queries.Rounds.GetAllBySeasonId;
 
 /// <summary>
@@ -19,9 +21,9 @@ public static class RoundSummaryDtoExtensions
     ///
     /// Returns the currently active round if one exists; otherwise falls back to the round with the highest RoundNumber.
     /// </summary>
-    public static RoundSummaryDto GetDefaultRound(this IReadOnlyCollection<RoundSummaryDto> rounds, DateTime today)
+    public static RoundSummaryDto GetDefaultRound(this IReadOnlyCollection<RoundSummaryDto> rounds, RoundClock clock)
     {
-        var active = rounds.FirstOrDefault(r => r.StartDate <= today && today <= r.EndDate);
+        var active = rounds.FirstOrDefault(r => clock.IsRoundActive(r.StartDate, r.EndDate));
         return active ?? rounds.Last();
     }
 }

--- a/src/Infrastructure/Repositories/LeagueSeasonUserRepository.cs
+++ b/src/Infrastructure/Repositories/LeagueSeasonUserRepository.cs
@@ -24,4 +24,10 @@ public class LeagueSeasonUserRepository(AppDbContext context) :
         => await DbSet
             .Where(lsu => lsu.LeagueSeasonId == leagueSeasonId && lsu.UserId == userId)
             .FirstOrDefaultAsync();
+
+    public async Task<Guid?> GetUserLeagueIdForSeasonAsync(Guid userId, Guid seasonId)
+        => await DbSet
+            .Where(lsu => lsu.UserId == userId && lsu.LeagueSeason.SeasonId == seasonId)
+            .Select(lsu => (Guid?)lsu.LeagueSeason.LeagueId)
+            .FirstOrDefaultAsync();
 }

--- a/src/Infrastructure/Repositories/SolveRepository.cs
+++ b/src/Infrastructure/Repositories/SolveRepository.cs
@@ -9,10 +9,10 @@ namespace BldLeague.Infrastructure.Repositories;
 public class SolveRepository(AppDbContext context) : 
     ReadWriteRepositoryBase<Solve>(context), ISolveRepository
 {
-    public async Task<IReadOnlyCollection<(Guid, SolveResult)>> GetBestSolvesForLeagueSeason(Guid leagueSeasonId)
+    public async Task<IReadOnlyCollection<(Guid, SolveResult)>> GetBestSolvesForLeagueSeason(Guid leagueSeasonId, DateTime cutoff)
     {
         var groups = await DbSet
-            .Where(s => s.Match.LeagueSeasonId == leagueSeasonId)
+            .Where(s => s.Match.LeagueSeasonId == leagueSeasonId && s.Match.Round.EndDate < cutoff)
             .GroupBy(s => s.UserId)
             .Select(g => new
             {

--- a/src/Web/Helpers/PageModelExtensions.cs
+++ b/src/Web/Helpers/PageModelExtensions.cs
@@ -1,0 +1,22 @@
+using System.Security.Claims;
+using BldLeague.Application.Queries.LeagueSeasons.GetUserLeagueIdForSeason;
+using MediatR;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace BldLeague.Web.Helpers;
+
+public static class PageModelExtensions
+{
+    public static async Task<Guid?> ResolveCurrentUserLeagueIdAsync(
+        this PageModel page,
+        IMediator mediator,
+        IReadOnlyCollection<Guid> availableLeagueIds,
+        Guid seasonId)
+    {
+        if (page.User.Identity?.IsAuthenticated != true) return null;
+        var userIdClaim = page.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!Guid.TryParse(userIdClaim, out var userId)) return null;
+        var userLeagueId = await mediator.Send(new GetUserLeagueIdForSeasonRequest(userId, seasonId));
+        return userLeagueId.HasValue && availableLeagueIds.Contains(userLeagueId.Value) ? userLeagueId : null;
+    }
+}

--- a/src/Web/Pages/Leagues/ViewLeague.cshtml.cs
+++ b/src/Web/Pages/Leagues/ViewLeague.cshtml.cs
@@ -1,6 +1,8 @@
+using System.Security.Claims;
 using BldLeague.Application.Queries.LeagueSeasons.GetAll;
 using BldLeague.Application.Queries.LeagueSeasons.GetDetail;
 using BldLeague.Application.Queries.LeagueSeasons.GetLeagueSeasonsForSeasonId;
+using BldLeague.Application.Queries.LeagueSeasons.GetUserLeagueIdForSeason;
 using BldLeague.Application.Queries.Seasons.GetAll;
 using BldLeague.Web.ViewModels;
 using MediatR;
@@ -37,12 +39,25 @@ public class ViewLeague(IMediator mediator) : PageModel
             return Page();
 
         if (LeagueId == Guid.Empty || !LeagueSeasons.Any(ls => ls.LeagueId == LeagueId))
-            LeagueId = LeagueSeasons.First().LeagueId;
+        {
+            var availableLeagueIds = LeagueSeasons.Select(ls => ls.LeagueId).ToList();
+            LeagueId = await ResolveDefaultLeagueIdAsync(availableLeagueIds, SeasonId)
+                       ?? LeagueSeasons.First().LeagueId;
+        }
 
         var dto = await mediator.Send(new GetLeagueSeasonDetailRequest(SeasonId, LeagueId));
         LeagueSeason = dto == null ? null : LeagueSeasonDetailViewModel.FromDto(dto);
 
         ModelState.Clear();
         return Page();
+    }
+
+    private async Task<Guid?> ResolveDefaultLeagueIdAsync(IReadOnlyCollection<Guid> availableLeagueIds, Guid seasonId)
+    {
+        if (User.Identity?.IsAuthenticated != true) return null;
+        var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!Guid.TryParse(userIdClaim, out var userId)) return null;
+        var userLeagueId = await mediator.Send(new GetUserLeagueIdForSeasonRequest(userId, seasonId));
+        return userLeagueId.HasValue && availableLeagueIds.Contains(userLeagueId.Value) ? userLeagueId : null;
     }
 }

--- a/src/Web/Pages/Leagues/ViewLeague.cshtml.cs
+++ b/src/Web/Pages/Leagues/ViewLeague.cshtml.cs
@@ -1,9 +1,8 @@
-using System.Security.Claims;
 using BldLeague.Application.Queries.LeagueSeasons.GetAll;
 using BldLeague.Application.Queries.LeagueSeasons.GetDetail;
 using BldLeague.Application.Queries.LeagueSeasons.GetLeagueSeasonsForSeasonId;
-using BldLeague.Application.Queries.LeagueSeasons.GetUserLeagueIdForSeason;
 using BldLeague.Application.Queries.Seasons.GetAll;
+using BldLeague.Web.Helpers;
 using BldLeague.Web.ViewModels;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
@@ -41,7 +40,7 @@ public class ViewLeague(IMediator mediator) : PageModel
         if (LeagueId == Guid.Empty || !LeagueSeasons.Any(ls => ls.LeagueId == LeagueId))
         {
             var availableLeagueIds = LeagueSeasons.Select(ls => ls.LeagueId).ToList();
-            LeagueId = await ResolveDefaultLeagueIdAsync(availableLeagueIds, SeasonId)
+            LeagueId = await this.ResolveCurrentUserLeagueIdAsync(mediator, availableLeagueIds, SeasonId)
                        ?? LeagueSeasons.First().LeagueId;
         }
 
@@ -50,14 +49,5 @@ public class ViewLeague(IMediator mediator) : PageModel
 
         ModelState.Clear();
         return Page();
-    }
-
-    private async Task<Guid?> ResolveDefaultLeagueIdAsync(IReadOnlyCollection<Guid> availableLeagueIds, Guid seasonId)
-    {
-        if (User.Identity?.IsAuthenticated != true) return null;
-        var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (!Guid.TryParse(userIdClaim, out var userId)) return null;
-        var userLeagueId = await mediator.Send(new GetUserLeagueIdForSeasonRequest(userId, seasonId));
-        return userLeagueId.HasValue && availableLeagueIds.Contains(userLeagueId.Value) ? userLeagueId : null;
     }
 }

--- a/src/Web/Pages/Matches/MatchList.cshtml
+++ b/src/Web/Pages/Matches/MatchList.cshtml
@@ -54,27 +54,44 @@
                 <tr>
                     <td class="text-end"><a asp-page="/Users/UserProfile" asp-route-id="@matchSummary.UserAId">@matchSummary.UserAFullName</a></td>
 
-                    @if (string.IsNullOrEmpty(matchSummary.UserBFullName))
+                    @if (matchSummary.Status == MatchStatus.Finished)
                     {
-                        <td class="text-center" colspan="3">N/A</td>
-                        <td></td>
-                    }
-                    else if (matchSummary.Status == MatchStatus.Finished)
-                    {
-                        <td class="text-center">@matchSummary.UserAScore</td>
-                        <td class="text-center">:</td>
-                        <td class="text-center">@matchSummary.UserBScore</td>
-                        <td><a asp-page="/Users/UserProfile" asp-route-id="@matchSummary.UserBId">@matchSummary.UserBFullName</a></td>
+                        @if (string.IsNullOrEmpty(matchSummary.UserBFullName))
+                        {
+                            <td class="text-center" colspan="3">N/A</td>
+                            <td></td>
+                        }
+                        else
+                        {
+                            <td class="text-center">@matchSummary.UserAScore</td>
+                            <td class="text-center">:</td>
+                            <td class="text-center">@matchSummary.UserBScore</td>
+                            <td><a asp-page="/Users/UserProfile" asp-route-id="@matchSummary.UserBId">@matchSummary.UserBFullName</a></td>
+                        }
                     }
                     else if (matchSummary.Status == MatchStatus.InProgress)
                     {
                         <td class="text-center" colspan="3"><span class="badge text-bg-warning">W trakcie</span></td>
-                        <td><a asp-page="/Users/UserProfile" asp-route-id="@matchSummary.UserBId">@matchSummary.UserBFullName</a></td>
+                        @if (string.IsNullOrEmpty(matchSummary.UserBFullName))
+                        {
+                            <td></td>
+                        }
+                        else
+                        {
+                            <td><a asp-page="/Users/UserProfile" asp-route-id="@matchSummary.UserBId">@matchSummary.UserBFullName</a></td>
+                        }
                     }
                     else
                     {
                         <td class="text-center" colspan="3"><span class="badge text-bg-secondary">Planowany</span></td>
-                        <td><a asp-page="/Users/UserProfile" asp-route-id="@matchSummary.UserBId">@matchSummary.UserBFullName</a></td>
+                        @if (string.IsNullOrEmpty(matchSummary.UserBFullName))
+                        {
+                            <td></td>
+                        }
+                        else
+                        {
+                            <td><a asp-page="/Users/UserProfile" asp-route-id="@matchSummary.UserBId">@matchSummary.UserBFullName</a></td>
+                        }
                     }
 
                     <td>

--- a/src/Web/Pages/Matches/MatchList.cshtml.cs
+++ b/src/Web/Pages/Matches/MatchList.cshtml.cs
@@ -1,5 +1,7 @@
+using System.Security.Claims;
 using BldLeague.Application.Common;
 using BldLeague.Application.Queries.Leagues.GetAll;
+using BldLeague.Application.Queries.LeagueSeasons.GetUserLeagueIdForSeason;
 using BldLeague.Application.Queries.Matches.GetMatchSummaries;
 using BldLeague.Application.Queries.Rounds.GetAllBySeasonId;
 using BldLeague.Application.Queries.Seasons.GetAll;
@@ -37,7 +39,11 @@ public class MatchList(IMediator mediator, RoundClock roundClock) : PageModel
             SeasonId = Seasons.First().Id;
 
         if (LeagueId == Guid.Empty || !Leagues.Any(l => l.Id == LeagueId))
-            LeagueId = Leagues.First().Id;
+        {
+            var availableLeagueIds = Leagues.Select(l => l.Id).ToList();
+            LeagueId = await ResolveDefaultLeagueIdAsync(availableLeagueIds, SeasonId)
+                       ?? Leagues.First().Id;
+        }
 
         Rounds = await mediator.Send(new GetAllRoundsBySeasonIdRequest(SeasonId));
 
@@ -49,5 +55,14 @@ public class MatchList(IMediator mediator, RoundClock roundClock) : PageModel
 
         ModelState.Clear();
         return Page();
+    }
+
+    private async Task<Guid?> ResolveDefaultLeagueIdAsync(IReadOnlyCollection<Guid> availableLeagueIds, Guid seasonId)
+    {
+        if (User.Identity?.IsAuthenticated != true) return null;
+        var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (!Guid.TryParse(userIdClaim, out var userId)) return null;
+        var userLeagueId = await mediator.Send(new GetUserLeagueIdForSeasonRequest(userId, seasonId));
+        return userLeagueId.HasValue && availableLeagueIds.Contains(userLeagueId.Value) ? userLeagueId : null;
     }
 }

--- a/src/Web/Pages/Matches/MatchList.cshtml.cs
+++ b/src/Web/Pages/Matches/MatchList.cshtml.cs
@@ -1,10 +1,9 @@
-using System.Security.Claims;
 using BldLeague.Application.Common;
 using BldLeague.Application.Queries.Leagues.GetAll;
-using BldLeague.Application.Queries.LeagueSeasons.GetUserLeagueIdForSeason;
 using BldLeague.Application.Queries.Matches.GetMatchSummaries;
 using BldLeague.Application.Queries.Rounds.GetAllBySeasonId;
 using BldLeague.Application.Queries.Seasons.GetAll;
+using BldLeague.Web.Helpers;
 using BldLeague.Web.ViewModels;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
@@ -41,28 +40,19 @@ public class MatchList(IMediator mediator, RoundClock roundClock) : PageModel
         if (LeagueId == Guid.Empty || !Leagues.Any(l => l.Id == LeagueId))
         {
             var availableLeagueIds = Leagues.Select(l => l.Id).ToList();
-            LeagueId = await ResolveDefaultLeagueIdAsync(availableLeagueIds, SeasonId)
+            LeagueId = await this.ResolveCurrentUserLeagueIdAsync(mediator, availableLeagueIds, SeasonId)
                        ?? Leagues.First().Id;
         }
 
         Rounds = await mediator.Send(new GetAllRoundsBySeasonIdRequest(SeasonId));
 
         if (Rounds.Any() && (RoundNumber == 0 || !Rounds.Any(r => r.RoundNumber == RoundNumber)))
-            RoundNumber = Rounds.GetDefaultRound(roundClock.LocalToday()).RoundNumber;
+            RoundNumber = Rounds.GetDefaultRound(roundClock).RoundNumber;
 
         var dtos = await mediator.Send(new GetMatchSummariesRequest(SeasonId, LeagueId, RoundNumber));
         MatchSummaries = dtos.Select(d => MatchSummaryViewModel.FromDto(d, roundClock)).ToList();
 
         ModelState.Clear();
         return Page();
-    }
-
-    private async Task<Guid?> ResolveDefaultLeagueIdAsync(IReadOnlyCollection<Guid> availableLeagueIds, Guid seasonId)
-    {
-        if (User.Identity?.IsAuthenticated != true) return null;
-        var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (!Guid.TryParse(userIdClaim, out var userId)) return null;
-        var userLeagueId = await mediator.Send(new GetUserLeagueIdForSeasonRequest(userId, seasonId));
-        return userLeagueId.HasValue && availableLeagueIds.Contains(userLeagueId.Value) ? userLeagueId : null;
     }
 }

--- a/src/Web/Pages/Matches/ViewMatch.cshtml
+++ b/src/Web/Pages/Matches/ViewMatch.cshtml
@@ -23,10 +23,16 @@
 
         <hr class="my-4" />
 
-        @if (Model.MatchDetails.Status != MatchStatus.Finished)
+        @if (Model.MatchDetails.Status == MatchStatus.Upcoming)
         {
             <div class="alert alert-secondary">
                 Mecz zaplanowany. Wyniki będą dostępne po zakończeniu kolejki.
+            </div>
+        }
+        else if (Model.MatchDetails.Status == MatchStatus.InProgress)
+        {
+            <div class="alert alert-info">
+                Mecz w trakcie. Wyniki będą dostępne po wgraniu wyników przez wszystkich zawodników.
             </div>
         }
         else

--- a/src/Web/Pages/Rounds/ViewRound.cshtml.cs
+++ b/src/Web/Pages/Rounds/ViewRound.cshtml.cs
@@ -37,7 +37,7 @@ public class ViewRound(IMediator mediator, RoundClock roundClock) : PageModel
             return Page();
 
         if (RoundNumber == 0 || !Rounds.Any(r => r.RoundNumber == RoundNumber))
-            RoundNumber = Rounds.GetDefaultRound(roundClock.LocalToday()).RoundNumber;
+            RoundNumber = Rounds.GetDefaultRound(roundClock).RoundNumber;
 
         var dto = await mediator.Send(new GetRoundDetailRequest(SeasonId, RoundNumber));
         RoundDetail = dto == null ? null : RoundDetailViewModel.FromDto(dto, roundClock);


### PR DESCRIPTION
Closes #73

## Summary

- BYE matches now correctly render `Planowany` / `W trakcie` / `N/A` based on `MatchStatus` (status drives the branch; BYE is only special-cased inside the Finished branch).
- `ViewMatch` info box distinguishes Upcoming ("po zakończeniu kolejki") from InProgress ("po wgraniu wyników").
- Season **BEST** column on `/Leagues` excludes in-progress solves: `GetBestSolvesForLeagueSeason` now takes a `cutoff` and the handler passes `RoundClock.LocalToday()`.
- `/Matches` and `/Rounds` default to the *active* round when one exists, falling back to the last round otherwise.
- `/Leagues` and `/Matches` default to the signed-in user's own league for the newest season (extension method on `PageModel`, shared across both pages).
- `GetDefaultRound` routes through `RoundClock.IsRoundActive` for consistency with the recent timing-semantics fixes.