### PR TITLE
chore: home-page polish, write-only submit, recent matches & round countdown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,8 @@ Avoid JavaScript by default. Prefer server-side form submissions and page reload
 | Round queries + DTOs (incl. `ScrambleDto`, `RoundSummaryDto`) | `src/Application/Queries/Rounds/` |
 | Match queries + DTOs (incl. `SolveDto`, `MatchDetailsDto`, `MatchExportRowDto`) | `src/Application/Queries/Matches/` |
 | Active submission query + `ActiveSubmissionDto` | `src/Application/Queries/Matches/GetActiveSubmission/` |
+| Recent finished matches query + `RecentMatchDto` | `src/Application/Queries/Matches/GetRecentFinishedMatches/` |
+| Active round query + `ActiveRoundDto` | `src/Application/Queries/Rounds/GetActiveRound/` |
 | User queries + DTOs (incl. `LeagueSeasonUserDto` for roster queries) | `src/Application/Queries/Users/` |
 | Player rankings query + DTOs (`SingleRankingDto`, `AverageRankingDto`) | `src/Application/Queries/PlayerRankings/` |
 | Player ranking by user ID | `src/Application/Queries/PlayerRankings/GetByUserId/` |

--- a/src/Application/Abstractions/Repositories/IMatchRepository.cs
+++ b/src/Application/Abstractions/Repositories/IMatchRepository.cs
@@ -2,6 +2,7 @@ using BldLeague.Application.Queries.Matches.GetAll;
 using BldLeague.Application.Queries.Matches.GetMatchDetailsById;
 using BldLeague.Application.Queries.Matches.GetMatchExport;
 using BldLeague.Application.Queries.Matches.GetMatchSummaries;
+using BldLeague.Application.Queries.Matches.GetRecentFinishedMatches;
 using BldLeague.Domain.Entities;
 
 namespace BldLeague.Application.Abstractions.Repositories;
@@ -19,4 +20,5 @@ public interface IMatchRepository : IReadWriteRepository<Match>
 
     Task<IReadOnlyCollection<Match>> GetFinishedMatchesByUserIdAsync(Guid userId, DateTime localToday);
     Task<Match?> GetActiveMatchForUserAsync(Guid userId, DateTime localToday);
+    Task<IReadOnlyList<RecentMatchDto>> GetRecentFinishedMatchesAsync(int count, DateTime localToday);
 }

--- a/src/Application/Abstractions/Repositories/IRoundRepository.cs
+++ b/src/Application/Abstractions/Repositories/IRoundRepository.cs
@@ -1,3 +1,4 @@
+using BldLeague.Application.Queries.Rounds.GetActiveRound;
 using BldLeague.Application.Queries.Rounds.GetAll;
 using BldLeague.Application.Queries.Rounds.GetAllBySeasonId;
 using BldLeague.Application.Queries.Rounds.GetDetail;
@@ -12,4 +13,5 @@ public interface IRoundRepository : IReadWriteRepository<Round>
     Task<RoundSummaryDto?> GetSummaryByIdAsync(Guid id);
     Task<int?> GetLatestRoundNumberAsync();
     Task<RoundDetailDto?> GetRoundDetailAsync(Guid seasonId, int roundNumber);
+    Task<IReadOnlyCollection<ActiveRoundSummaryDto>> GetRoundsActiveOnDateAsync(DateTime localToday);
 }

--- a/src/Application/Common/RoundClock.cs
+++ b/src/Application/Common/RoundClock.cs
@@ -25,4 +25,9 @@ public class RoundClock(TimeZoneInfo timeZone)
 
     public DateTime ToLocal(DateTime utc)
         => TimeZoneInfo.ConvertTimeFromUtc(DateTime.SpecifyKind(utc, DateTimeKind.Utc), timeZone);
+
+    public DateTime LocalDayEndToUtc(DateTime localEndDate)
+        => TimeZoneInfo.ConvertTimeToUtc(
+            DateTime.SpecifyKind(localEndDate.Date.AddDays(1), DateTimeKind.Unspecified),
+            timeZone);
 }

--- a/src/Application/Queries/Matches/GetRecentFinishedMatches/GetRecentFinishedMatchesRequest.cs
+++ b/src/Application/Queries/Matches/GetRecentFinishedMatches/GetRecentFinishedMatchesRequest.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace BldLeague.Application.Queries.Matches.GetRecentFinishedMatches;
+
+public record GetRecentFinishedMatchesRequest(int Count) : IRequest<IReadOnlyList<RecentMatchDto>>;

--- a/src/Application/Queries/Matches/GetRecentFinishedMatches/GetRecentFinishedMatchesRequestHandler.cs
+++ b/src/Application/Queries/Matches/GetRecentFinishedMatches/GetRecentFinishedMatchesRequestHandler.cs
@@ -1,0 +1,15 @@
+using BldLeague.Application.Abstractions.Repositories;
+using BldLeague.Application.Common;
+using MediatR;
+
+namespace BldLeague.Application.Queries.Matches.GetRecentFinishedMatches;
+
+public class GetRecentFinishedMatchesRequestHandler(IUnitOfWork unitOfWork, RoundClock roundClock)
+    : IRequestHandler<GetRecentFinishedMatchesRequest, IReadOnlyList<RecentMatchDto>>
+{
+    public async Task<IReadOnlyList<RecentMatchDto>> Handle(GetRecentFinishedMatchesRequest request, CancellationToken cancellationToken)
+    {
+        var localToday = roundClock.LocalToday();
+        return await unitOfWork.MatchRepository.GetRecentFinishedMatchesAsync(request.Count, localToday);
+    }
+}

--- a/src/Application/Queries/Matches/GetRecentFinishedMatches/RecentMatchDto.cs
+++ b/src/Application/Queries/Matches/GetRecentFinishedMatches/RecentMatchDto.cs
@@ -1,0 +1,10 @@
+namespace BldLeague.Application.Queries.Matches.GetRecentFinishedMatches;
+
+public class RecentMatchDto
+{
+    public Guid MatchId { get; init; }
+    public required string UserAFullName { get; init; }
+    public string? UserBFullName { get; init; }
+    public int UserAScore { get; init; }
+    public int UserBScore { get; init; }
+}

--- a/src/Application/Queries/Rounds/GetActiveRound/ActiveRoundDto.cs
+++ b/src/Application/Queries/Rounds/GetActiveRound/ActiveRoundDto.cs
@@ -1,0 +1,9 @@
+namespace BldLeague.Application.Queries.Rounds.GetActiveRound;
+
+public class ActiveRoundDto
+{
+    public Guid RoundId { get; init; }
+    public int RoundNumber { get; init; }
+    public int SeasonNumber { get; init; }
+    public DateTime EndsAtUtc { get; init; }
+}

--- a/src/Application/Queries/Rounds/GetActiveRound/ActiveRoundDto.cs
+++ b/src/Application/Queries/Rounds/GetActiveRound/ActiveRoundDto.cs
@@ -2,8 +2,6 @@ namespace BldLeague.Application.Queries.Rounds.GetActiveRound;
 
 public class ActiveRoundDto
 {
-    public Guid RoundId { get; init; }
     public int RoundNumber { get; init; }
-    public int SeasonNumber { get; init; }
     public DateTime EndsAtUtc { get; init; }
 }

--- a/src/Application/Queries/Rounds/GetActiveRound/ActiveRoundSummaryDto.cs
+++ b/src/Application/Queries/Rounds/GetActiveRound/ActiveRoundSummaryDto.cs
@@ -1,0 +1,10 @@
+namespace BldLeague.Application.Queries.Rounds.GetActiveRound;
+
+public class ActiveRoundSummaryDto
+{
+    public Guid RoundId { get; init; }
+    public int RoundNumber { get; init; }
+    public int SeasonNumber { get; init; }
+    public DateTime StartDate { get; init; }
+    public DateTime EndDate { get; init; }
+}

--- a/src/Application/Queries/Rounds/GetActiveRound/GetActiveRoundRequest.cs
+++ b/src/Application/Queries/Rounds/GetActiveRound/GetActiveRoundRequest.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace BldLeague.Application.Queries.Rounds.GetActiveRound;
+
+public record GetActiveRoundRequest : IRequest<ActiveRoundDto?>;

--- a/src/Application/Queries/Rounds/GetActiveRound/GetActiveRoundRequestHandler.cs
+++ b/src/Application/Queries/Rounds/GetActiveRound/GetActiveRoundRequestHandler.cs
@@ -1,0 +1,32 @@
+using BldLeague.Application.Abstractions.Repositories;
+using BldLeague.Application.Common;
+using MediatR;
+
+namespace BldLeague.Application.Queries.Rounds.GetActiveRound;
+
+public class GetActiveRoundRequestHandler(IUnitOfWork unitOfWork, RoundClock roundClock)
+    : IRequestHandler<GetActiveRoundRequest, ActiveRoundDto?>
+{
+    public async Task<ActiveRoundDto?> Handle(GetActiveRoundRequest request, CancellationToken cancellationToken)
+    {
+        var localToday = roundClock.LocalToday();
+        var rounds = await unitOfWork.RoundRepository.GetRoundsActiveOnDateAsync(localToday);
+
+        var round = rounds
+            .Where(r => roundClock.IsRoundActive(r.StartDate, r.EndDate))
+            .OrderByDescending(r => r.SeasonNumber)
+            .ThenByDescending(r => r.RoundNumber)
+            .FirstOrDefault();
+
+        if (round == null)
+            return null;
+
+        return new ActiveRoundDto
+        {
+            RoundId = round.RoundId,
+            RoundNumber = round.RoundNumber,
+            SeasonNumber = round.SeasonNumber,
+            EndsAtUtc = roundClock.LocalDayEndToUtc(round.EndDate),
+        };
+    }
+}

--- a/src/Application/Queries/Rounds/GetActiveRound/GetActiveRoundRequestHandler.cs
+++ b/src/Application/Queries/Rounds/GetActiveRound/GetActiveRoundRequestHandler.cs
@@ -23,9 +23,7 @@ public class GetActiveRoundRequestHandler(IUnitOfWork unitOfWork, RoundClock rou
 
         return new ActiveRoundDto
         {
-            RoundId = round.RoundId,
             RoundNumber = round.RoundNumber,
-            SeasonNumber = round.SeasonNumber,
             EndsAtUtc = roundClock.LocalDayEndToUtc(round.EndDate),
         };
     }

--- a/src/Infrastructure/Repositories/MatchRepository.cs
+++ b/src/Infrastructure/Repositories/MatchRepository.cs
@@ -3,6 +3,7 @@ using BldLeague.Application.Queries.Matches.GetAll;
 using BldLeague.Application.Queries.Matches.GetMatchDetailsById;
 using BldLeague.Application.Queries.Matches.GetMatchExport;
 using BldLeague.Application.Queries.Matches.GetMatchSummaries;
+using BldLeague.Application.Queries.Matches.GetRecentFinishedMatches;
 using BldLeague.Application.Queries.Rounds.GetScrambles;
 using BldLeague.Domain.Entities;
 using BldLeague.Infrastructure.Context;
@@ -183,4 +184,48 @@ public class MatchRepository(AppDbContext context)
                         && m.Round.StartDate <= localToday
                         && m.Round.EndDate >= localToday)
             .FirstOrDefaultAsync();
+
+    public async Task<IReadOnlyList<RecentMatchDto>> GetRecentFinishedMatchesAsync(int count, DateTime localToday)
+    {
+        var candidates = await DbSet
+            .Where(m => (m.UserASubmittedAt != null && (m.UserBId == null || m.UserBSubmittedAt != null))
+                        || m.Round.EndDate < localToday)
+            .OrderByDescending(m => m.Round.EndDate)
+            .ThenByDescending(m => m.Id)
+            .Take(count * 4)
+            .Select(m => new
+            {
+                m.Id,
+                UserAFullName = m.UserA.FullName,
+                UserBFullName = m.UserB != null ? m.UserB.FullName : null,
+                m.UserAScore,
+                m.UserBScore,
+                m.UserASubmittedAt,
+                m.UserBSubmittedAt,
+                RoundEndDate = m.Round.EndDate,
+            })
+            .ToListAsync();
+
+        return candidates
+            .Select(m =>
+            {
+                var effectiveAt = m.UserASubmittedAt.HasValue && m.UserBSubmittedAt.HasValue
+                    ? (m.UserASubmittedAt > m.UserBSubmittedAt ? m.UserASubmittedAt : m.UserBSubmittedAt)
+                    : m.UserASubmittedAt ?? m.UserBSubmittedAt ?? (DateTime?)m.RoundEndDate;
+
+                return (dto: new RecentMatchDto
+                {
+                    MatchId = m.Id,
+                    UserAFullName = m.UserAFullName,
+                    UserBFullName = m.UserBFullName,
+                    UserAScore = m.UserAScore,
+                    UserBScore = m.UserBScore,
+                }, effectiveAt);
+            })
+            .OrderByDescending(x => x.effectiveAt)
+            .ThenByDescending(x => x.dto.MatchId)
+            .Take(count)
+            .Select(x => x.dto)
+            .ToList();
+    }
 }

--- a/src/Infrastructure/Repositories/RoundRepository.cs
+++ b/src/Infrastructure/Repositories/RoundRepository.cs
@@ -1,4 +1,5 @@
 using BldLeague.Application.Abstractions.Repositories;
+using BldLeague.Application.Queries.Rounds.GetActiveRound;
 using BldLeague.Application.Queries.Rounds.GetAll;
 using BldLeague.Application.Queries.Rounds.GetAllBySeasonId;
 using BldLeague.Application.Queries.Rounds.GetDetail;
@@ -69,4 +70,17 @@ public class RoundRepository(AppDbContext context) :
                     .ToList()
             })
             .FirstOrDefaultAsync();
+
+    public async Task<IReadOnlyCollection<ActiveRoundSummaryDto>> GetRoundsActiveOnDateAsync(DateTime localToday)
+        => await DbSet
+            .Where(r => r.StartDate <= localToday && r.EndDate >= localToday)
+            .Select(r => new ActiveRoundSummaryDto
+            {
+                RoundId = r.Id,
+                RoundNumber = r.RoundNumber,
+                SeasonNumber = r.Season.SeasonNumber,
+                StartDate = r.StartDate,
+                EndDate = r.EndDate,
+            })
+            .ToListAsync();
 }

--- a/src/Web/Pages/About/About.cshtml
+++ b/src/Web/Pages/About/About.cshtml
@@ -32,7 +32,7 @@
             <p class="mb-1">Obecnie aplikacja jest w fazie beta.</p>
             <p class="mb-1">Planowane funkcje:</p>
             <ul class="mb-3">
-                <li>Logowanie przez konto WCA i samodzielne wgrywanie wyników</li>
+                <li><s>Logowanie przez konto WCA i samodzielne wgrywanie wyników</s> <span class="badge bg-success">Dodane</span></li>
                 <li><s>Profile użytkowników z historią ułożeń, najlepszymi czasami itp.</s> <span class="badge bg-success">Dodane</span></li>
                 <li><s>Rankingi</s> <span class="badge bg-success">Dodane</span></li>
                 <li>Statystyki</li>
@@ -51,6 +51,18 @@
         </div>
         <div class="card-body p-0">
             <ul class="list-group list-group-flush">
+                <li class="list-group-item">
+                    <div class="d-flex justify-content-between align-items-start">
+                        <div>
+                            <strong>0.4.0</strong>
+                            <span class="badge bg-primary ms-2">Beta</span>
+                        </div>
+                        <small class="text-muted">12.04.2026</small>
+                    </div>
+                    <ul class="mt-2 mb-0 ps-3">
+                        <li>Samodzielne wgrywanie wyników na stronie</li>
+                    </ul>
+                </li>
                 <li class="list-group-item">
                     <div class="d-flex justify-content-between align-items-start">
                         <div>

--- a/src/Web/Pages/Index.cshtml
+++ b/src/Web/Pages/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+@page
 @model IndexModel
 <div class="row align-items-center py-5 mb-2">
     <div class="col-md-7">
@@ -21,6 +21,20 @@
         <img src="images/blder_head.png" alt="Speedcuber wearing a blindfold icon" width="256" />
     </div>
 </div>
+
+@if (Model.ActiveRound != null)
+{
+    <div id="round-countdown"
+         class="alert alert-secondary alert-dismissible d-flex align-items-center gap-2 mb-3"
+         data-round-id="@Model.ActiveRound.RoundId"
+         data-ends-at="@Model.ActiveRound.EndsAtUtc.ToString("o")"
+         hidden>
+        <i class="bi bi-clock me-1"></i>
+        Kolejka @Model.ActiveRound.RoundNumber kończy się za
+        <strong id="round-countdown-text"></strong>
+        <button type="button" class="btn-close ms-auto" aria-label="Zamknij"></button>
+    </div>
+}
 
 <hr class="mb-4">
 
@@ -93,30 +107,124 @@
     @if (Model.ActiveSubmission != null)
     {
         <div class="col-12 col-sm-6 col-md-4">
-            <a asp-page="/Submit/SubmitResults" class="text-decoration-none">
-                <div class="card h-100 border-0 shadow-sm p-3">
-                    <div class="d-flex align-items-center gap-3">
-                        <i class="bi bi-pencil-square fs-2" style="color: var(--bs-purple)"></i>
-                        <div>
-                            <div class="fw-semibold">Mój aktywny mecz</div>
-                            <div class="text-muted small">
-                                @Model.ActiveSubmission.RoundName —
-                                @(string.IsNullOrEmpty(Model.ActiveSubmission.OpponentName) ? "BYE" : Model.ActiveSubmission.OpponentName)
+            @if (Model.ActiveSubmission.HasSubmitted)
+            {
+                <a asp-page="/Matches/ViewMatch" asp-route-id="@Model.ActiveSubmission.MatchId" class="text-decoration-none">
+                    <div class="card h-100 border-0 shadow-sm p-3">
+                        <div class="d-flex align-items-center gap-3">
+                            <i class="bi bi-pencil-square fs-2" style="color: var(--bs-purple)"></i>
+                            <div>
+                                <div class="fw-semibold">Aktywny mecz</div>
+                                <div class="text-muted small">
+                                    @if (string.IsNullOrEmpty(Model.ActiveSubmission.OpponentName))
+                                    {
+                                        <span>BYE</span>
+                                    }
+                                    else
+                                    {
+                                        <span>Rywal: @Model.ActiveSubmission.OpponentName</span>
+                                    }
+                                </div>
+                                <div class="mt-1">
+                                    <span class="badge bg-secondary">Zobacz</span>
+                                </div>
                             </div>
-                            <div class="mt-1">
-                                @if (!Model.ActiveSubmission.HasSubmitted)
-                                {
+                        </div>
+                    </div>
+                </a>
+            }
+            else
+            {
+                <a asp-page="/Submit/SubmitResults" class="text-decoration-none">
+                    <div class="card h-100 border-0 shadow-sm p-3">
+                        <div class="d-flex align-items-center gap-3">
+                            <i class="bi bi-pencil-square fs-2" style="color: var(--bs-purple)"></i>
+                            <div>
+                                <div class="fw-semibold">Aktywny mecz</div>
+                                <div class="text-muted small">
+                                    @if (string.IsNullOrEmpty(Model.ActiveSubmission.OpponentName))
+                                    {
+                                        <span>BYE</span>
+                                    }
+                                    else
+                                    {
+                                        <span>Rywal: @Model.ActiveSubmission.OpponentName</span>
+                                    }
+                                </div>
+                                <div class="mt-1">
                                     <span class="badge bg-primary">Wgraj wyniki</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </a>
+            }
+        </div>
+    }
+</div>
+
+@if (Model.RecentMatches.Count > 0)
+{
+    <h5 class="mt-4 mb-3">Ostatnie mecze</h5>
+    <div class="row g-3">
+        @foreach (var m in Model.RecentMatches)
+        {
+            <div class="col-12 col-sm-6 col-md-4">
+                <a asp-page="/Matches/ViewMatch" asp-route-id="@m.MatchId" class="text-decoration-none">
+                    <div class="card h-100 border-0 shadow-sm p-3">
+                        <div class="d-flex align-items-center gap-3">
+                            <i class="bi bi-stopwatch fs-2 text-secondary"></i>
+                            <div>
+                                @if (string.IsNullOrEmpty(m.UserBFullName))
+                                {
+                                    <div class="fw-semibold">@m.UserAFullName</div>
+                                    <div class="text-muted small">wolny los</div>
                                 }
                                 else
                                 {
-                                    <span class="badge bg-secondary">Zobacz</span>
+                                    <div class="fw-semibold">@m.UserAFullName @m.UserAScore:@m.UserBScore @m.UserBFullName</div>
                                 }
                             </div>
                         </div>
                     </div>
-                </div>
-            </a>
-        </div>
-    }
-</div>
+                </a>
+            </div>
+        }
+    </div>
+}
+
+@section Scripts {
+    <script>
+        (function () {
+            const el = document.getElementById('round-countdown');
+            if (!el) return;
+            const roundId = el.dataset.roundId;
+            const hiddenKey = 'bld-countdown-hidden:' + roundId;
+            if (localStorage.getItem(hiddenKey) === '1') return;
+            el.hidden = false;
+            const endsAt = new Date(el.dataset.endsAt).getTime();
+            const txt = document.getElementById('round-countdown-text');
+            function tick() {
+                const ms = endsAt - Date.now();
+                if (ms <= 0) { el.hidden = true; clearInterval(t); return; }
+                const s = Math.floor(ms / 1000);
+                const days = Math.floor(s / 86400);
+                const hours = Math.floor((s % 86400) / 3600);
+                const minutes = Math.floor((s % 3600) / 60);
+                const seconds = s % 60;
+                txt.textContent =
+                    (days > 0 ? days + 'd ' : '') +
+                    String(hours).padStart(2, '0') + ':' +
+                    String(minutes).padStart(2, '0') + ':' +
+                    String(seconds).padStart(2, '0');
+            }
+            tick();
+            const t = setInterval(tick, 1000);
+            el.querySelector('.btn-close').addEventListener('click', function () {
+                localStorage.setItem(hiddenKey, '1');
+                el.hidden = true;
+                clearInterval(t);
+            });
+        })();
+    </script>
+}

--- a/src/Web/Pages/Index.cshtml
+++ b/src/Web/Pages/Index.cshtml
@@ -25,14 +25,10 @@
 @if (Model.ActiveRound != null)
 {
     <div id="round-countdown"
-         class="alert alert-secondary alert-dismissible d-flex align-items-center gap-2 mb-3"
-         data-round-id="@Model.ActiveRound.RoundId"
-         data-ends-at="@Model.ActiveRound.EndsAtUtc.ToString("o")"
-         hidden>
+         class="small text-muted mb-2"
+         data-ends-at="@Model.ActiveRound.EndsAtUtc.ToString("o")">
         <i class="bi bi-clock me-1"></i>
-        Kolejka @Model.ActiveRound.RoundNumber kończy się za
-        <strong id="round-countdown-text"></strong>
-        <button type="button" class="btn-close ms-auto" aria-label="Zamknij"></button>
+        Kolejka @Model.ActiveRound.RoundNumber kończy się za <strong id="round-countdown-text"></strong>
     </div>
 }
 
@@ -198,10 +194,6 @@
         (function () {
             const el = document.getElementById('round-countdown');
             if (!el) return;
-            const roundId = el.dataset.roundId;
-            const hiddenKey = 'bld-countdown-hidden:' + roundId;
-            if (localStorage.getItem(hiddenKey) === '1') return;
-            el.hidden = false;
             const endsAt = new Date(el.dataset.endsAt).getTime();
             const txt = document.getElementById('round-countdown-text');
             function tick() {
@@ -220,11 +212,6 @@
             }
             tick();
             const t = setInterval(tick, 1000);
-            el.querySelector('.btn-close').addEventListener('click', function () {
-                localStorage.setItem(hiddenKey, '1');
-                el.hidden = true;
-                clearInterval(t);
-            });
         })();
     </script>
 }

--- a/src/Web/Pages/Index.cshtml.cs
+++ b/src/Web/Pages/Index.cshtml.cs
@@ -1,5 +1,7 @@
 using System.Security.Claims;
 using BldLeague.Application.Queries.Matches.GetActiveSubmission;
+using BldLeague.Application.Queries.Matches.GetRecentFinishedMatches;
+using BldLeague.Application.Queries.Rounds.GetActiveRound;
 using MediatR;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
@@ -12,6 +14,8 @@ public class IndexModel(IMediator mediator) : PageModel
     public string? Role { get; set; }
     public string? ThumbnailUrl { get; set; }
     public ActiveSubmissionDto? ActiveSubmission { get; set; }
+    public IReadOnlyList<RecentMatchDto> RecentMatches { get; set; } = [];
+    public ActiveRoundDto? ActiveRound { get; set; }
 
     public async Task OnGet()
     {
@@ -28,5 +32,8 @@ public class IndexModel(IMediator mediator) : PageModel
                 ActiveSubmission = await mediator.Send(new GetActiveSubmissionRequest(userId));
             }
         }
+
+        RecentMatches = await mediator.Send(new GetRecentFinishedMatchesRequest(3));
+        ActiveRound = await mediator.Send(new GetActiveRoundRequest());
     }
 }

--- a/src/Web/Pages/Matches/ViewMatch.cshtml
+++ b/src/Web/Pages/Matches/ViewMatch.cshtml
@@ -34,16 +34,15 @@
             <div class="alert alert-info">
                 Mecz w trakcie. Wyniki będą dostępne po wgraniu wyników przez wszystkich zawodników.
             </div>
+            @if (Model.ViewerSubmittedAt != null)
+            {
+                <div class="alert alert-info">
+                    Wyniki zostały wgrane (@Model.ViewerSubmittedAt). Skontaktuj się z administratorem, jeśli musisz je poprawić.
+                </div>
+            }
         }
         else
         {
-
-        @if (!Model.MatchDetails.IsRoundFinished)
-        {
-            <div class="alert alert-info">
-                Scramble będą dostępne po zakończeniu kolejki.
-            </div>
-        }
 
         <div>
             <table class="table table-hover align-middle">
@@ -137,6 +136,19 @@
                 </tbody>
             </table>
         </div>
+
+        @if (!Model.MatchDetails.IsRoundFinished)
+        {
+            <div class="alert alert-info">
+                Scramble będą dostępne po zakończeniu kolejki.
+            </div>
+        }
+        @if (Model.ViewerSubmittedAt != null)
+        {
+            <div class="alert alert-info">
+                Wyniki zostały wgrane (@Model.ViewerSubmittedAt). Skontaktuj się z administratorem, jeśli musisz je poprawić.
+            </div>
+        }
         }
     }
 </div>

--- a/src/Web/Pages/Matches/ViewMatch.cshtml.cs
+++ b/src/Web/Pages/Matches/ViewMatch.cshtml.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using BldLeague.Application.Common;
 using BldLeague.Application.Queries.Matches.GetMatchDetailsById;
 using BldLeague.Web.ViewModels;
@@ -14,9 +15,30 @@ public class ViewMatch(IMediator mediator, RoundClock roundClock) : PageModel
 
     public MatchDetailsViewModel? MatchDetails { get; set; }
 
+    /// <summary>
+    /// Local-time string of when the current viewer submitted their results, or null if not a participant / not yet submitted.
+    /// </summary>
+    public string? ViewerSubmittedAt { get; set; }
+
     public async Task OnGet()
     {
         var dto = await mediator.Send(new GetMatchDetailsByIdRequest(Id));
-        MatchDetails = dto == null ? null : MatchDetailsViewModel.FromDto(dto, roundClock);
+        if (dto == null)
+            return;
+
+        MatchDetails = MatchDetailsViewModel.FromDto(dto, roundClock);
+
+        var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userIdClaim != null && Guid.TryParse(userIdClaim, out var viewerId))
+        {
+            DateTime? submittedAt = null;
+            if (viewerId == dto.UserAId)
+                submittedAt = dto.UserASubmittedAt;
+            else if (viewerId == dto.UserBId)
+                submittedAt = dto.UserBSubmittedAt;
+
+            if (submittedAt.HasValue)
+                ViewerSubmittedAt = roundClock.ToLocal(submittedAt.Value).ToString("yyyy-MM-dd HH:mm");
+        }
     }
 }

--- a/src/Web/Pages/Submit/SubmitResults.cshtml
+++ b/src/Web/Pages/Submit/SubmitResults.cshtml
@@ -3,7 +3,7 @@
 @model BldLeague.Web.Pages.Submit.SubmitResults
 
 <div class="container mt-2">
-    <h2>Mój aktywny mecz</h2>
+    <h2>Aktywny mecz</h2>
 
     @if (TempData["ErrorMessage"] != null)
     {
@@ -13,81 +13,41 @@
     @if (Model.ActiveSubmission != null)
     {
         <p class="text-muted">
-            @Model.ActiveSubmission.RoundName
-            @if (!string.IsNullOrEmpty(Model.ActiveSubmission.LeagueIdentifier))
-            {
-                <span>— @Model.ActiveSubmission.LeagueIdentifier</span>
-            }
             @if (!string.IsNullOrEmpty(Model.ActiveSubmission.OpponentName))
             {
-                <span>— vs @Model.ActiveSubmission.OpponentName</span>
+                <span>Rywal: @Model.ActiveSubmission.OpponentName</span>
             }
             else
             {
-                <span>— BYE</span>
+                <span>BYE</span>
             }
         </p>
 
-        @if (!Model.HasSubmitted)
-        {
-            <form method="post">
-                <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
-
-                @for (var i = 0; i < Match.SOLVES_PER_MATCH; i++)
-                {
-                    var scramble = i < Model.ActiveSubmission.Scrambles.Count
-                        ? Model.ActiveSubmission.Scrambles[i]
-                        : null;
-
-                    <div class="mb-3">
-                        <label class="form-label fw-semibold">Ułożenie @(i + 1)</label>
-                        @if (scramble != null)
-                        {
-                            <div class="font-monospace text-muted mb-1 small">@scramble.Notation</div>
-                        }
-                        <input asp-for="Solves[i].Result"
-                               class="form-control"
-                               placeholder="np. 12.34 lub DNF" />
-                        <span asp-validation-for="Solves[i].Result" class="text-danger"></span>
-                    </div>
-                }
-
-                <button type="submit" class="btn btn-primary"
-                        onclick="return confirm('Czy na pewno chcesz wgrać wyniki? Tej operacji nie można cofnąć.');">Wgraj wyniki</button>
-                <a asp-page="/Index" class="btn btn-outline-secondary ms-2">Anuluj</a>
-            </form>
-        }
-        else
-        {
-            <div class="alert alert-info">
-                Wyniki zostały wgrane
-                @if (Model.SubmittedAtLocal != null)
-                {
-                    <span>(@Model.SubmittedAtLocal)</span>
-                }
-                . Skontaktuj się z administratorem, jeśli musisz je poprawić.
-            </div>
+        <form method="post">
+            <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
 
             @for (var i = 0; i < Match.SOLVES_PER_MATCH; i++)
             {
                 var scramble = i < Model.ActiveSubmission.Scrambles.Count
                     ? Model.ActiveSubmission.Scrambles[i]
                     : null;
-                var result = i < Model.ActiveSubmission.SubmittedSolves.Count
-                    ? Model.ActiveSubmission.SubmittedSolves[i]
-                    : "—";
 
                 <div class="mb-3">
-                    <div class="fw-semibold">Ułożenie @(i + 1)</div>
+                    <label class="form-label fw-semibold">Ułożenie @(i + 1)</label>
                     @if (scramble != null)
                     {
-                        <div class="font-monospace text-muted small">@scramble.Notation</div>
+                        <div class="font-monospace text-muted mb-1 small">@scramble.Notation</div>
                     }
-                    <div>@result</div>
+                    <input asp-for="Solves[i].Result"
+                           class="form-control"
+                           placeholder="np. 12.34 lub DNF" />
+                    <span asp-validation-for="Solves[i].Result" class="text-danger"></span>
                 </div>
             }
 
-            <a asp-page="/Index" class="btn btn-outline-secondary">Powrót</a>
-        }
+            <button type="submit" class="btn btn-primary"
+                    onclick="return confirm('Czy na pewno chcesz wgrać wyniki? Tej operacji nie można cofnąć.');">Wgraj wyniki</button>
+            <a asp-page="/Index" class="btn btn-outline-secondary ms-2">Anuluj</a>
+        </form>
     }
 </div>

--- a/src/Web/Pages/Submit/SubmitResults.cshtml.cs
+++ b/src/Web/Pages/Submit/SubmitResults.cshtml.cs
@@ -11,11 +11,9 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 namespace BldLeague.Web.Pages.Submit;
 
 [Authorize]
-public class SubmitResults(IMediator mediator, RoundClock roundClock) : PageModel
+public class SubmitResults(IMediator mediator) : PageModel
 {
     public ActiveSubmissionDto? ActiveSubmission { get; set; }
-    public bool HasSubmitted { get; set; }
-    public string? SubmittedAtLocal { get; set; }
 
     [BindProperty]
     public List<SubmitSolveDto> Solves { get; set; } = Enumerable
@@ -36,10 +34,9 @@ public class SubmitResults(IMediator mediator, RoundClock roundClock) : PageMode
             return RedirectToPage("/Index");
         }
 
-        HasSubmitted = ActiveSubmission.HasSubmitted;
-        SubmittedAtLocal = ActiveSubmission.SubmittedAt.HasValue
-            ? roundClock.ToLocal(ActiveSubmission.SubmittedAt.Value).ToString("yyyy-MM-dd HH:mm")
-            : null;
+        if (ActiveSubmission.HasSubmitted)
+            return RedirectToPage("/Matches/ViewMatch", new { id = ActiveSubmission.MatchId });
+
         return Page();
     }
 
@@ -66,6 +63,7 @@ public class SubmitResults(IMediator mediator, RoundClock roundClock) : PageMode
             return Page();
         }
 
-        return RedirectToPage();
+        var submission = await mediator.Send(new GetActiveSubmissionRequest(userId));
+        return RedirectToPage("/Matches/ViewMatch", new { id = submission!.MatchId });
     }
 }


### PR DESCRIPTION
Closes #75

## Summary

- Home page: active-match tile links to ViewMatch when the player has already submitted; otherwise it links to SubmitResults. Subtext shows the opponent name (or "BYE").
- New "Ostatnie mecze" section under the tile grid showing up to 3 most recently finished matches (visible to anonymous users too).
- Round countdown: a compact muted line above the page divider showing the time remaining until the active round ends. DST-safe via `RoundClock.LocalDayEndToUtc`.
- Submit page: when the viewer has already submitted, redirect to ViewMatch instead of showing the read-only branch. The read-only template was removed.
- ViewMatch: shows a "Wyniki zostały wgrane" notice for participants who already submitted.
- About page: marked self-service submission as delivered and added a 0.4.0 changelog entry.

## New application code

- Query: `GetActiveRoundRequest` / `ActiveRoundDto` — returns the currently active round (if any) with a UTC end instant for the JS countdown.
- Query: `GetRecentFinishedMatchesRequest` / `RecentMatchDto` — returns the N most-recently finalized matches, sorted by the later of the two submission timestamps (fallback: round end date).
- Repository additions: `IRoundRepository.GetRoundsActiveOnDateAsync`, `IMatchRepository.GetRecentFinishedMatchesAsync`.
- `RoundClock.LocalDayEndToUtc(DateTime localEndDate)` helper.
