### PR TITLE
fix: persist auth cookie across browser restarts

### DIFF
--- a/src/Web/Auth/AuthenticationExtensions.cs
+++ b/src/Web/Auth/AuthenticationExtensions.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using BldLeague.Application.Commands.Users.UpdateAvatar;
 using BldLeague.Application.Queries.Users.GetById;
 using BldLeague.Application.Queries.Users.GetUserDetailByWcaId;
+using BldLeague.Web.Options;
 using MediatR;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
@@ -13,12 +14,15 @@ namespace BldLeague.Web.Auth;
 
 public static class AuthenticationExtensions
 {
-    private static readonly TimeSpan ClaimsRefreshInterval = TimeSpan.FromMinutes(5);
-
-    public static AuthenticationBuilder AddRefreshingCookie(this AuthenticationBuilder builder)
+    public static AuthenticationBuilder AddRefreshingCookie(this AuthenticationBuilder builder, AuthOptions authOptions)
     {
+        var claimsRefreshInterval = TimeSpan.FromMinutes(authOptions.ClaimsRefreshMinutes);
+        var cookieExpireTimeSpan = TimeSpan.FromDays(authOptions.CookieExpireDays);
+
         return builder.AddCookie(options =>
         {
+            options.ExpireTimeSpan = cookieExpireTimeSpan;
+            options.SlidingExpiration = true;
             options.Events = new CookieAuthenticationEvents
             {
                 OnValidatePrincipal = async context =>
@@ -26,7 +30,7 @@ public static class AuthenticationExtensions
                     var refreshedAtValue = context.Principal?.FindFirstValue("claims_refreshed_at");
                     if (refreshedAtValue != null
                         && DateTime.TryParse(refreshedAtValue, null, System.Globalization.DateTimeStyles.RoundtripKind, out var lastRefresh)
-                        && DateTime.UtcNow - lastRefresh < ClaimsRefreshInterval)
+                        && DateTime.UtcNow - lastRefresh < claimsRefreshInterval)
                     {
                         return;
                     }

--- a/src/Web/Options/AuthOptions.cs
+++ b/src/Web/Options/AuthOptions.cs
@@ -1,0 +1,8 @@
+namespace BldLeague.Web.Options;
+
+public class AuthOptions
+{
+    public const string SectionName = "Auth";
+    public int ClaimsRefreshMinutes { get; set; } = 10;
+    public int CookieExpireDays { get; set; } = 14;
+}

--- a/src/Web/Pages/Account/Login.cshtml.cs
+++ b/src/Web/Pages/Account/Login.cshtml.cs
@@ -10,7 +10,8 @@ public class Login : PageModel
     {
         return Challenge(new AuthenticationProperties
         {
-            RedirectUri = "/"
+            RedirectUri = "/",
+            IsPersistent = true
         }, "WCA");
     }
 }

--- a/src/Web/Pages/Account/RefreshAvatar.cshtml.cs
+++ b/src/Web/Pages/Account/RefreshAvatar.cshtml.cs
@@ -16,7 +16,8 @@ public class RefreshAvatar : PageModel
         await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
         return Challenge(new AuthenticationProperties
         {
-            RedirectUri = userId != null ? $"/Users/{userId}" : "/"
+            RedirectUri = userId != null ? $"/Users/{userId}" : "/",
+            IsPersistent = true
         }, "WCA");
     }
 }

--- a/src/Web/Program.cs
+++ b/src/Web/Program.cs
@@ -22,13 +22,19 @@ builder.Services.AddBldLeagueApplication(builder.Configuration["MediatR:LicenseK
 
 builder.Services.Configure<EnvironmentBadgeOptions>(builder.Configuration.GetSection("EnvironmentBadge"));
 
+var authOptions = builder.Configuration
+    .GetSection(AuthOptions.SectionName)
+    .Get<AuthOptions>() ?? new AuthOptions();
+
+builder.Services.Configure<AuthOptions>(builder.Configuration.GetSection(AuthOptions.SectionName));
+
 builder.Services.AddAuthentication(options =>
     {
         options.DefaultAuthenticateScheme = CookieAuthenticationDefaults.AuthenticationScheme;
         options.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
         options.DefaultChallengeScheme = "WCA";
     })
-    .AddRefreshingCookie()
+    .AddRefreshingCookie(authOptions)
     .AddWcaOAuth(builder.Configuration.GetSection("WCA"));
 
 var app = builder.Build();

--- a/src/Web/appsettings.json
+++ b/src/Web/appsettings.json
@@ -28,5 +28,9 @@
     "TimeZoneId": "Europe/Warsaw",
     "Hour": 0,
     "Minute": 1
+  },
+  "Auth": {
+    "ClaimsRefreshMinutes": 10,
+    "CookieExpireDays": 14
   }
 }


### PR DESCRIPTION
Closes #82

Sets `IsPersistent = true` on the auth `Challenge` so the WCA cookie survives browser restarts, and introduces a new `Auth` configuration section (`ClaimsRefreshMinutes`, `CookieExpireDays`) so the claims refresh interval (now 10 min) and cookie lifetime (14 days, sliding) can be tuned without a redeploy.