### PR TITLE
Render 'Aktywny mecz' tile in all states on home page

### DIFF
--- a/src/Web/Pages/Index.cshtml
+++ b/src/Web/Pages/Index.cshtml
@@ -100,9 +100,9 @@
             </div>
         </a>
     </div>
-    @if (Model.ActiveSubmission != null)
-    {
-        <div class="col-12 col-sm-6 col-md-4">
+    <div class="col-12 col-sm-6 col-md-4">
+        @if (Model.ActiveSubmission != null)
+        {
             @if (Model.ActiveSubmission.HasSubmitted)
             {
                 <a asp-page="/Matches/ViewMatch" asp-route-id="@Model.ActiveSubmission.MatchId" class="text-decoration-none">
@@ -155,8 +155,33 @@
                     </div>
                 </a>
             }
-        </div>
-    }
+        }
+        else
+        {
+            <div class="card h-100 border-0 shadow-sm p-3">
+                <div class="d-flex align-items-center gap-3">
+                    <i class="bi bi-pencil-square fs-2 text-muted"></i>
+                    <div>
+                        <div class="fw-semibold text-muted">Aktywny mecz</div>
+                        <div class="text-muted small">
+                            @if (Model.ActiveRound == null)
+                            {
+                                <span>Brak aktywnej kolejki</span>
+                            }
+                            else if (!Model.IsAuthenticated)
+                            {
+                                <span>Zaloguj się, aby wgrać wyniki</span>
+                            }
+                            else
+                            {
+                                <span>Nie bierzesz udziału w tej kolejce</span>
+                            }
+                        </div>
+                    </div>
+                </div>
+            </div>
+        }
+    </div>
 </div>
 
 @if (Model.RecentMatches.Count > 0)


### PR DESCRIPTION
Closes #84

The "Aktywny mecz" tile now renders in all four states (no active round / not signed in / not participating / has match) instead of vanishing. Inactive states render a muted card without a link wrapper; the existing active-match markup is preserved unchanged.