### PR TITLE
Make summary tiles update live

### DIFF
--- a/src/Application/Abstractions/Repositories/IStatisticsRepository.cs
+++ b/src/Application/Abstractions/Repositories/IStatisticsRepository.cs
@@ -7,14 +7,18 @@ using BldLeague.Domain.ValueObjects;
 namespace BldLeague.Application.Abstractions.Repositories;
 
 /// <summary>
-/// Raw projections for the global statistics surface. All queries are scoped to
-/// finished rounds only — callers pass <c>localToday</c> from <c>RoundClock.LocalToday()</c>
-/// and the repository applies <c>round.EndDate &lt; localToday</c>.
+/// Raw projections for the global statistics surface. Most queries are scoped to
+/// finished rounds only — see per-method docs. Callers pass <c>localToday</c> from
+/// <c>RoundClock.LocalToday()</c> and the repository applies <c>round.EndDate &lt; localToday</c>
+/// (or a per-match equivalent) where appropriate.
 /// </summary>
 public interface IStatisticsRepository
 {
     /// <summary>
-    /// Returns aggregate counters (valid solves, attempts, finished matches, distinct participants).
+    /// Returns aggregate counters with mixed semantics: <c>ValidSolves</c> and <c>Attempts</c>
+    /// are live (every submitted solve counts, regardless of round status); <c>Matches</c> is
+    /// live too — counted when the round has ended or both sides have submitted; <c>Participants</c>
+    /// stays finished-only (distinct users with at least one finished-match appearance).
     /// </summary>
     Task<StatisticsSummaryDto> GetSummaryAsync(DateTime localToday);
 

--- a/src/Application/Queries/Statistics/GetStatisticsSummary/StatisticsSummaryDto.cs
+++ b/src/Application/Queries/Statistics/GetStatisticsSummary/StatisticsSummaryDto.cs
@@ -1,10 +1,12 @@
 namespace BldLeague.Application.Queries.Statistics.GetStatisticsSummary;
 
 /// <summary>
-/// Global counters for the home page and statistics page header tiles.
+/// Global counters for the home page and statistics page header tiles. Mixed semantics:
+/// solve and match counters update live (reflecting submissions in the active round),
+/// while the participants counter stays scoped to finished matches.
 /// </summary>
-/// <param name="ValidSolves">Count of valid (non-DNF, non-DNS) solves on finished matches.</param>
-/// <param name="Attempts">Valid + DNF solves on finished matches (DNS excluded).</param>
-/// <param name="Matches">Count of finished matches, including BYE matches.</param>
-/// <param name="Participants">Count of distinct users that have at least one finished-match appearance.</param>
+/// <param name="ValidSolves">Live count of valid (non-DNF, non-DNS) solves across all matches — submitted solves on active rounds are included immediately.</param>
+/// <param name="Attempts">Live count of valid + DNF solves across all matches (DNS excluded) — submitted solves on active rounds are included immediately.</param>
+/// <param name="Matches">Live count of matches that have ended (round end date passed) or had both sides submit, including BYE matches.</param>
+/// <param name="Participants">Count of distinct users that have at least one finished-match appearance. Finished-only — does not change until a round flips to finished.</param>
 public record StatisticsSummaryDto(int ValidSolves, int Attempts, int Matches, int Participants);

--- a/src/Infrastructure/Repositories/StatisticsRepository.cs
+++ b/src/Infrastructure/Repositories/StatisticsRepository.cs
@@ -20,11 +20,19 @@ public class StatisticsRepository(AppDbContext context) : IStatisticsRepository
 
     public async Task<StatisticsSummaryDto> GetSummaryAsync(DateTime localToday)
     {
-        // SolveResult stores -1 for DNF and -2 for DNS; valid solves have non-negative centiseconds.
-        var validCount = await FinishedSolves(localToday).CountAsync(s => s.Result >= 0);
-        var attemptsCount = await FinishedSolves(localToday).CountAsync(s => s.Result != -2);
-        var matchCount = await FinishedMatches(localToday).CountAsync();
+        // Live: any submitted solve, regardless of round status. SolveResult stores -1 for DNF and -2 for DNS;
+        // valid solves have non-negative centiseconds.
+        var validCount = await context.Set<Solve>().CountAsync(s => s.Result >= 0);
+        var attemptsCount = await context.Set<Solve>().CountAsync(s => s.Result != -2);
 
+        // Live: a match is "played" when its round has ended OR both sides have submitted.
+        // The OR-clause mirrors Match.BothSidesSubmitted; inlined here so EF translates it to SQL.
+        var matchCount = await context.Set<Match>()
+            .CountAsync(m =>
+                m.Round.EndDate < localToday
+                || (m.UserASubmittedAt != null && (m.UserBId == null || m.UserBSubmittedAt != null)));
+
+        // Unchanged: finished-only distinct participants.
         var participantsA = FinishedMatches(localToday).Select(m => m.UserAId);
         var participantsB = FinishedMatches(localToday)
             .Where(m => m.UserBId != null)


### PR DESCRIPTION
## Summary

Drop the finished-rounds filter from two of the three global statistics tiles so they update live:

- **Ułożonych kostek** — every submitted `Solve` (regardless of round status)
- **Rozegranych meczów** — match counts where `Round.EndDate < localToday` **OR** `BothSidesSubmitted`

**Uczestników** stays gated to finished rounds, and every other stat on `/Statistics` (Ao12, Ao25, accuracy, streaks, season/league records, histograms, heatmap, score distribution) is untouched — solve times do not leak.

Closes #93
