### PR TITLE
chore: pre-0.5.0 polish (nav icons, footer, /Statistics mobile, /About)

### DIFF
--- a/src/Infrastructure/Repositories/MatchRepository.cs
+++ b/src/Infrastructure/Repositories/MatchRepository.cs
@@ -189,7 +189,8 @@ public class MatchRepository(AppDbContext context)
     {
         var candidates = await DbSet
             .Where(m => (m.UserASubmittedAt != null && (m.UserBId == null || m.UserBSubmittedAt != null))
-                        || m.Round.EndDate < localToday)
+                        || (m.Round.EndDate < localToday
+                            && (m.UserASubmittedAt != null || m.UserBSubmittedAt != null)))
             .OrderByDescending(m => m.Round.EndDate)
             .ThenByDescending(m => m.Id)
             .Take(count * 4)

--- a/src/Web/Pages/About/About.cshtml
+++ b/src/Web/Pages/About/About.cshtml
@@ -35,7 +35,7 @@
                 <li><s>Logowanie przez konto WCA i samodzielne wgrywanie wyników</s> <span class="badge bg-success">Dodane</span></li>
                 <li><s>Profile użytkowników z historią ułożeń, najlepszymi czasami itp.</s> <span class="badge bg-success">Dodane</span></li>
                 <li><s>Rankingi</s> <span class="badge bg-success">Dodane</span></li>
-                <li>Statystyki</li>
+                <li><s>Statystyki</s> <span class="badge bg-success">Dodane</span></li>
             </ul>
             <p class="mb-2">Autorem aplikacji jest <strong>Kamil Przybylski</strong>.</p>
             <a href="https://github.com/kamilprzyb2/bld-league" class="btn btn-outline-secondary btn-sm" target="_blank" rel="noopener noreferrer">
@@ -51,6 +51,23 @@
         </div>
         <div class="card-body p-0">
             <ul class="list-group list-group-flush">
+                <li class="list-group-item">
+                    <div class="d-flex justify-content-between align-items-start">
+                        <div>
+                            <strong>0.5.0</strong>
+                            <span class="badge bg-primary ms-2">Beta</span>
+                        </div>
+                        <small class="text-muted">28.05.2026</small>
+                    </div>
+                    <ul class="mt-2 mb-0 ps-3">
+                        <li>Globalne statystyki strony (nowy widok /Statistics + sekcja na stronie głównej)</li>
+                        <li>Przeprojektowane kafelki "Ostatnie mecze" + nowy widok /Matches/Recent</li>
+                        <li>Kafelek "Aktywny mecz" widoczny na stronie głównej w każdym stanie</li>
+                        <li>Widok "na żywo" aktywnej kolejki na /Rounds z podziałem na zgłoszone i oczekujące mecze</li>
+                        <li>Ikony w menu nawigacji</li>
+                        <li>Naprawione kasowanie ciasteczka logowania po zamknięciu przeglądarki</li>
+                    </ul>
+                </li>
                 <li class="list-group-item">
                     <div class="d-flex justify-content-between align-items-start">
                         <div>

--- a/src/Web/Pages/Index.cshtml
+++ b/src/Web/Pages/Index.cshtml
@@ -209,8 +209,8 @@
             <partial name="_StatTile" model="tile" />
         }
     </div>
-    <div class="text-end mt-2">
-        <a asp-page="/Statistics/Statistics" class="text-decoration-none">Zobacz więcej →</a>
+    <div class="d-flex justify-content-end mt-2">
+        <a asp-page="/Statistics/Statistics" class="small">Zobacz więcej</a>
     </div>
 }
 

--- a/src/Web/Pages/Shared/_Layout.cshtml
+++ b/src/Web/Pages/Shared/_Layout.cshtml
@@ -59,11 +59,12 @@
                             Wyniki <i class="bi bi-chevron-down nav-chevron"></i>
                         </a>
                         <ul class="dropdown-menu">
-                            <li><a class="dropdown-item" asp-area="" asp-page="/Leagues/ViewLeague">Ligi</a></li>
-                            <li><a class="dropdown-item" asp-area="" asp-page="/Rounds/ViewRound">Kolejki</a></li>
-                            <li><a class="dropdown-item" asp-area="" asp-page="/Matches/MatchList">Mecze</a></li>
-                            <li><a class="dropdown-item" asp-area="" asp-page="/Rankings/Rankings">Rankingi</a></li>
-                            <li><a class="dropdown-item" asp-area="" asp-page="/Users/UserList">Osoby</a></li>
+                            <li><a class="dropdown-item" asp-area="" asp-page="/Leagues/ViewLeague"><i class="bi bi-trophy text-warning" style="margin-right: 0.5rem;"></i>Ligi</a></li>
+                            <li><a class="dropdown-item" asp-area="" asp-page="/Rounds/ViewRound"><i class="bi bi-calendar3 text-primary" style="margin-right: 0.5rem;"></i>Kolejki</a></li>
+                            <li><a class="dropdown-item" asp-area="" asp-page="/Matches/MatchList"><i class="bi bi-stopwatch text-danger" style="margin-right: 0.5rem;"></i>Mecze</a></li>
+                            <li><a class="dropdown-item" asp-area="" asp-page="/Rankings/Rankings"><i class="bi bi-bar-chart-line text-success" style="margin-right: 0.5rem;"></i>Rankingi</a></li>
+                            <li><a class="dropdown-item" asp-area="" asp-page="/Users/UserList"><i class="bi bi-person-circle" style="margin-right: 0.5rem; color: #ed8257"></i>Osoby</a></li>
+                            <li><a class="dropdown-item" asp-area="" asp-page="/Statistics/Statistics"><i class="bi bi-pie-chart text-info" style="margin-right: 0.5rem;"></i>Statystyki</a></li>
                         </ul>
                     </li>
                     <li class="nav-item dropdown">
@@ -72,9 +73,9 @@
                             Informacje <i class="bi bi-chevron-down nav-chevron"></i>
                         </a>
                         <ul class="dropdown-menu">
-                            <li><a class="dropdown-item" asp-area="" asp-page="/About/Guidelines">Zasady</a></li>
-                            <li><a class="dropdown-item" asp-area="" asp-page="/About/About">O projekcie</a></li>
-                            <li><a class="dropdown-item" asp-area="" asp-page="/About/Privacy">Polityka prywatności</a></li>
+                            <li><a class="dropdown-item" asp-area="" asp-page="/About/Guidelines"><i class="bi bi-journal-text text-warning" style="margin-right: 0.5rem;"></i>Zasady</a></li>
+                            <li><a class="dropdown-item" asp-area="" asp-page="/About/About"><i class="bi bi-info-circle text-info" style="margin-right: 0.5rem;"></i>O projekcie</a></li>
+                            <li><a class="dropdown-item" asp-area="" asp-page="/About/Privacy"><i class="bi bi-shield-lock text-success" style="margin-right: 0.5rem;"></i>Polityka prywatności</a></li>
                         </ul>
                     </li>
                     @if (User.IsInRole("Admin"))
@@ -85,13 +86,13 @@
                                 Zarządzanie <i class="bi bi-chevron-down nav-chevron"></i>
                             </a>
                             <ul class="dropdown-menu">
-                                <li><a class="dropdown-item" asp-area="" asp-page="/Admin/Users/AllUsers">Użytkownicy</a></li>
-                                <li><a class="dropdown-item" asp-area="" asp-page="/Admin/Leagues/AllLeagues">Ligi</a></li>
-                                <li><a class="dropdown-item" asp-area="" asp-page="/Admin/Seasons/AllSeasons">Sezony</a></li>
-                                <li><a class="dropdown-item" asp-area="" asp-page="/Admin/Rounds/AllRounds">Kolejki</a></li>
-                                <li><a class="dropdown-item" asp-area="" asp-page="/Admin/LeagueSeasons/AllLeagueSeasons">Ligo-sezony</a></li>
-                                <li><a class="dropdown-item" asp-area="" asp-page="/Admin/Matches/AllMatches">Mecze</a></li>
-                                <li><a class="dropdown-item" asp-area="" asp-page="/Admin/Rankings/Rankings">Rankingi</a></li>
+                                <li><a class="dropdown-item" asp-area="" asp-page="/Admin/Users/AllUsers"><i class="bi bi-gear" style="margin-right: 0.5rem;"></i>Użytkownicy</a></li>
+                                <li><a class="dropdown-item" asp-area="" asp-page="/Admin/Leagues/AllLeagues"><i class="bi bi-gear" style="margin-right: 0.5rem;"></i>Ligi</a></li>
+                                <li><a class="dropdown-item" asp-area="" asp-page="/Admin/Seasons/AllSeasons"><i class="bi bi-gear" style="margin-right: 0.5rem;"></i>Sezony</a></li>
+                                <li><a class="dropdown-item" asp-area="" asp-page="/Admin/Rounds/AllRounds"><i class="bi bi-gear" style="margin-right: 0.5rem;"></i>Kolejki</a></li>
+                                <li><a class="dropdown-item" asp-area="" asp-page="/Admin/LeagueSeasons/AllLeagueSeasons"><i class="bi bi-gear" style="margin-right: 0.5rem;"></i>Ligo-sezony</a></li>
+                                <li><a class="dropdown-item" asp-area="" asp-page="/Admin/Matches/AllMatches"><i class="bi bi-gear" style="margin-right: 0.5rem;"></i>Mecze</a></li>
+                                <li><a class="dropdown-item" asp-area="" asp-page="/Admin/Rankings/Rankings"><i class="bi bi-gear" style="margin-right: 0.5rem;"></i>Rankingi</a></li>
                             </ul>
                         </li>
                     }
@@ -185,6 +186,7 @@
         <a asp-page="/About/About">O projekcie</a>
         <span class="mx-2">|</span>
         <a asp-page="/About/Privacy">Polityka prywatności</a>
+        <div class="small mt-1">&copy; 2026 Kamil Przybylski</div>
     </div>
 </footer>
 

--- a/src/Web/Pages/Shared/_Layout.cshtml
+++ b/src/Web/Pages/Shared/_Layout.cshtml
@@ -181,12 +181,13 @@
 
 <footer class="border-top footer text-muted">
     <div class="container text-center">
-        <a asp-page="/About/Guidelines">Zasady ligi</a>
+        <a class="text-nowrap" asp-page="/About/Guidelines">Zasady ligi</a>
         <span class="mx-2">|</span>
-        <a asp-page="/About/About">O projekcie</a>
+        <a class="text-nowrap" asp-page="/About/About">O projekcie</a>
         <span class="mx-2">|</span>
-        <a asp-page="/About/Privacy">Polityka prywatności</a>
-        <div class="small mt-1">&copy; 2026 Kamil Przybylski</div>
+        <a class="text-nowrap" asp-page="/About/Privacy">Polityka prywatności</a>
+        <span class="mx-2">|</span>
+        <span class="text-nowrap">&copy; 2026 Kamil Przybylski</span>
     </div>
 </footer>
 

--- a/src/Web/Pages/Shared/_Layout.cshtml.css
+++ b/src/Web/Pages/Shared/_Layout.cshtml.css
@@ -40,9 +40,5 @@ button.accept-policy {
 }
 
 .footer {
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-  white-space: nowrap;
-  line-height: 60px;
+  padding: 1rem 0;
 }

--- a/src/Web/Pages/Statistics/Statistics.cshtml
+++ b/src/Web/Pages/Statistics/Statistics.cshtml
@@ -144,7 +144,6 @@
                             <th>Zawodnik</th>
                             <th class="text-nowrap">Ao12</th>
                             <th class="d-none d-md-table-cell">Wyniki</th>
-                            <th class="d-md-none"></th>
                         </tr>
                     </thead>
                     <tbody>
@@ -158,23 +157,22 @@
                                 parts.Add(SolveFormatHelper.FormatWithParens(window, j));
                             }
                             var solvesText = string.Join(", ", parts);
-                            var rowClass = i >= 5 ? "stats-extra-row ao12-extra" : null;
+                            var classes = new List<string> { "js-stats-solves-row" };
+                            if (i >= 5)
+                            {
+                                classes.Add("stats-extra-row");
+                                classes.Add("ao12-extra");
+                            }
+                            var rowClass = string.Join(" ", classes);
                             var rowStyle = i >= 5 ? "display: none;" : null;
-                            <tr class="@rowClass" style="@rowStyle">
+                            <tr class="@rowClass" style="@rowStyle"
+                                data-solves="@solvesText" data-player="@entry.FullName">
                                 <td>@(i + 1)</td>
                                 <td>
                                     <a asp-page="/Users/UserProfile" asp-route-id="@entry.UserId">@entry.FullName</a>
                                 </td>
                                 <td class="fw-bold text-nowrap">@entry.BestAo12.ToString()</td>
                                 <td class="d-none d-md-table-cell">@solvesText</td>
-                                <td class="d-md-none text-end">
-                                    <button type="button" class="btn btn-link btn-sm p-0"
-                                            data-bs-toggle="modal" data-bs-target="#solvesModal"
-                                            data-solves="@solvesText" data-player="@entry.FullName"
-                                            aria-label="Pokaż ułożenia">
-                                        <i class="bi bi-list-ul"></i>
-                                    </button>
-                                </td>
                             </tr>
                         }
                     </tbody>
@@ -207,7 +205,6 @@
                             <th>Zawodnik</th>
                             <th class="text-nowrap">Ao25</th>
                             <th class="d-none d-md-table-cell">Wyniki</th>
-                            <th class="d-md-none"></th>
                         </tr>
                     </thead>
                     <tbody>
@@ -221,23 +218,22 @@
                                 parts.Add(SolveFormatHelper.FormatWithParens(window, j, dropCount: 2));
                             }
                             var solvesText = string.Join(", ", parts);
-                            var rowClass = i >= 5 ? "stats-extra-row ao25-extra" : null;
+                            var classes = new List<string> { "js-stats-solves-row" };
+                            if (i >= 5)
+                            {
+                                classes.Add("stats-extra-row");
+                                classes.Add("ao25-extra");
+                            }
+                            var rowClass = string.Join(" ", classes);
                             var rowStyle = i >= 5 ? "display: none;" : null;
-                            <tr class="@rowClass" style="@rowStyle">
+                            <tr class="@rowClass" style="@rowStyle"
+                                data-solves="@solvesText" data-player="@entry.FullName">
                                 <td>@(i + 1)</td>
                                 <td>
                                     <a asp-page="/Users/UserProfile" asp-route-id="@entry.UserId">@entry.FullName</a>
                                 </td>
                                 <td class="fw-bold text-nowrap">@entry.BestAo25.ToString()</td>
                                 <td class="d-none d-md-table-cell">@solvesText</td>
-                                <td class="d-md-none text-end">
-                                    <button type="button" class="btn btn-link btn-sm p-0"
-                                            data-bs-toggle="modal" data-bs-target="#solvesModal"
-                                            data-solves="@solvesText" data-player="@entry.FullName"
-                                            aria-label="Pokaż ułożenia">
-                                        <i class="bi bi-list-ul"></i>
-                                    </button>
-                                </td>
                             </tr>
                         }
                     </tbody>
@@ -449,6 +445,14 @@
     }
 </div>
 
+@section Styles {
+    <style>
+        @@media (max-width: 767.98px) {
+            tr.js-stats-solves-row { cursor: pointer; }
+        }
+    </style>
+}
+
 @section HeadScripts {
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.4/dist/chart.umd.min.js"></script>
 }
@@ -526,15 +530,21 @@
                 });
             }
 
-            // Shared solves modal — copy the data-* payload from the clicked button into the modal body.
+            // Shared solves modal — open on row click (mobile only), reading data-* attributes from the row.
+            // Mirrors the js-round-row pattern on UserProfile: clicks on inner <a> still navigate (link wins).
             var modalEl = document.getElementById('solvesModal');
             if (modalEl) {
-                modalEl.addEventListener('show.bs.modal', function (ev) {
-                    var btn = ev.relatedTarget;
-                    if (!btn) return;
-                    document.getElementById('solvesModalLabel').textContent = btn.getAttribute('data-player') || 'Ułożenia';
-                    document.getElementById('solvesModalBody').textContent = btn.getAttribute('data-solves') || '';
-                });
+                var modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+                var rows = document.querySelectorAll('tr.js-stats-solves-row');
+                for (var rIdx = 0; rIdx < rows.length; rIdx++) {
+                    rows[rIdx].addEventListener('click', function (ev) {
+                        if (window.innerWidth >= 768) return;
+                        var row = ev.currentTarget;
+                        document.getElementById('solvesModalLabel').textContent = row.getAttribute('data-player') || 'Ułożenia';
+                        document.getElementById('solvesModalBody').textContent = row.getAttribute('data-solves') || '';
+                        modal.show();
+                    });
+                }
             }
         })();
     </script>

--- a/src/Web/wwwroot/css/site.css
+++ b/src/Web/wwwroot/css/site.css
@@ -12,13 +12,14 @@ html {
   box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem #258cfb;
 }
 
-html {
-  position: relative;
-  min-height: 100%;
+body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
-body {
-  margin-bottom: 60px;
+body > .container {
+  flex: 1 0 auto;
 }
 
 .form-floating > .form-control-plaintext::placeholder, .form-floating > .form-control::placeholder {


### PR DESCRIPTION
Closes #94

## Summary

- Unified the two home-page "Zobacz więcej" links (Statystyki now matches Ostatnie mecze — `small`, default underline, no arrow).
- Nav menu: icons + colors on every dropdown item, plus a new `Statystyki` entry at the end of Wyniki.
- /Statistics Ao12 + Ao25 tables: dropped the mobile-only icon button column, made the whole `<tr>` clickable on `< 768px` (reuses the `js-round-row` pattern from UserProfile).
- Footer: copyright line `© 2026 Kamil Przybylski` added inline (each entry `text-nowrap` so the line only ever breaks at the `|` separators). Replaced the legacy absolute-positioned 60px-line-height sticky-footer trick with a flexbox sticky-footer so the footer can grow / wrap naturally on narrow screens.
- /About: `0.5.0 / Beta / 28.05.2026` changelog entry added at the top; `Statystyki` in "Planowane funkcje" struck through with green `Dodane` badge.
- Bonus fix: `GetRecentFinishedMatchesAsync` no longer returns matches from past rounds where neither player submitted, so phantom 0:0 tiles stop appearing in Ostatnie mecze.
